### PR TITLE
Do not use global namespace

### DIFF
--- a/src/Export/CSVExporter.php
+++ b/src/Export/CSVExporter.php
@@ -10,6 +10,7 @@
 
 namespace Hschottm\SurveyBundle\Export;
 
+use Contao\StringUtil;
 use Exporter\Writer\CsvWriter;
 
 class CSVExporter extends Exporter
@@ -72,7 +73,7 @@ class CSVExporter extends Exporter
         }
         $this->spreadsheet->close();
         header('Content-type: text/csv');
-        header('Content-Disposition: attachment; filename="'.\StringUtil::sanitizeFileName(htmlspecialchars_decode($this->filename)).'.csv'.'"');
+        header('Content-Disposition: attachment; filename="'.StringUtil::sanitizeFileName(htmlspecialchars_decode($this->filename)).'.csv'.'"');
         readfile($this->tempName);
         unlink($this->tempName);
         exit;

--- a/src/Export/ExcelExporterPhpSpreadsheet.php
+++ b/src/Export/ExcelExporterPhpSpreadsheet.php
@@ -10,9 +10,10 @@
 
 namespace Hschottm\SurveyBundle\Export;
 
+use Contao\StringUtil;
+use Hschottm\SurveyBundle\Export\Exporter;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
-use PhpOffice\PhpSpreadsheet\Writer\Xls;
 use PhpOffice\PhpSpreadsheet\Writer\Xlsx;
 
 class ExcelExporterPhpSpreadsheet extends Exporter
@@ -83,7 +84,7 @@ class ExcelExporterPhpSpreadsheet extends Exporter
     {
         $objWriter = new Xlsx($this->spreadsheet);
         header('Content-Type: application/vnd.ms-excel');
-        header('Content-Disposition: attachment;filename="'.\StringUtil::sanitizeFileName(htmlspecialchars_decode($this->filename)).'.xlsx"');
+        header('Content-Disposition: attachment;filename="'.StringUtil::sanitizeFileName(htmlspecialchars_decode($this->filename)).'.xlsx"');
         header('Cache-Control: max-age=0');
         $objWriter->save('php://output');
         echo '';
@@ -104,15 +105,15 @@ class ExcelExporterPhpSpreadsheet extends Exporter
         $font_array = [];
 
         switch ($cell[self::CELLTYPE]) {
-      case CELLTYPE_STRING:
+      case self::CELLTYPE_STRING:
         $worksheet->getStyle($pos)->getNumberFormat()->setFormatCode(\PhpOffice\PhpSpreadsheet\Style\NumberFormat::FORMAT_TEXT);
         break;
-      case CELLTYPE_FLOAT:
+      case self::CELLTYPE_FLOAT:
         $worksheet->getStyle($pos)->getNumberFormat()->setFormatCode(\PhpOffice\PhpSpreadsheet\Style\NumberFormat::FORMAT_NUMBER_00);
         break;
-      case CELLTYPE_PICTURE:
+      case self::CELLTYPE_PICTURE:
         break;
-      case CELLTYPE_INTEGER:
+      case self::CELLTYPE_INTEGER:
       default:
         $worksheet->getStyle($pos)->getNumberFormat()->setFormatCode(\PhpOffice\PhpSpreadsheet\Style\NumberFormat::FORMAT_NUMBER);
         break;

--- a/src/Export/ExcelExporterXLSExport.php
+++ b/src/Export/ExcelExporterXLSExport.php
@@ -10,6 +10,7 @@
 
 namespace Hschottm\SurveyBundle\Export;
 
+use Contao\StringUtil;
 use Hschottm\ExcelXLSBundle\xlsexport;
 
 class ExcelExporterXLSExport extends Exporter
@@ -61,7 +62,7 @@ class ExcelExporterXLSExport extends Exporter
 
     protected function send()
     {
-        $this->spreadsheet->sendFile(\StringUtil::sanitizeFileName(htmlspecialchars_decode($this->filename)).'.xls');
+        $this->spreadsheet->sendFile(StringUtil::sanitizeFileName(htmlspecialchars_decode($this->filename)).'.xls');
         exit;
     }
 
@@ -87,16 +88,16 @@ class ExcelExporterXLSExport extends Exporter
         $this->spreadsheet->setcell($data);
 
         switch ($cell[self::CELLTYPE]) {
-      case CELLTYPE_STRING:
+      case self::CELLTYPE_STRING:
         $data['type'] = CELL_STRING;
         break;
-      case CELLTYPE_FLOAT:
+      case self::CELLTYPE_FLOAT:
         $data['type'] = CELL_FLOAT;
         break;
-      case CELLTYPE_PICTURE:
+      case self::CELLTYPE_PICTURE:
         $data['type'] = CELL_PICTURE;
         break;
-      case CELLTYPE_INTEGER:
+      case self::CELLTYPE_INTEGER:
       default:
         break;
     }

--- a/src/Resources/contao/classes/Survey.php
+++ b/src/Resources/contao/classes/Survey.php
@@ -10,7 +10,9 @@
 
 namespace Hschottm\SurveyBundle;
 
-class Survey extends \Backend
+use Contao\Backend;
+
+class Survey extends Backend
 {
     /**
      * Import String library.

--- a/src/Resources/contao/classes/SurveyHelper.php
+++ b/src/Resources/contao/classes/SurveyHelper.php
@@ -2,8 +2,9 @@
 
 namespace Hschottm\SurveyBundle;
 
+use Contao\Backend;
 
-class SurveyHelper extends \Backend
+class SurveyHelper extends Backend
 {
 	/**
 	 * Load the database object

--- a/src/Resources/contao/classes/SurveyPINTAN.php
+++ b/src/Resources/contao/classes/SurveyPINTAN.php
@@ -206,7 +206,7 @@ class SurveyPINTAN extends Backend
         $this->Template->hrefBack = ampersand(str_replace('&key=createtan', '', Environment::get('request')));
         $this->Template->goBack = $GLOBALS['TL_LANG']['MSC']['goBack'];
         $this->Template->headline = $GLOBALS['TL_LANG']['tl_survey_pin_tan']['createtan'];
-        $this->Template->request = ampersand(Environment::get('request'), ENCODE_AMPERSANDS);
+        $this->Template->request = StringUtil::ampersand(Environment::get('request'));
         $this->Template->submit = StringUtil::specialchars($GLOBALS['TL_LANG']['tl_survey_pin_tan']['create']);
 
         // Create import form

--- a/src/Resources/contao/classes/SurveyPINTAN.php
+++ b/src/Resources/contao/classes/SurveyPINTAN.php
@@ -10,7 +10,16 @@
 
 namespace Hschottm\SurveyBundle;
 
+use Contao\Backend;
+use Contao\BackendTemplate;
 use Contao\DataContainer;
+use Contao\Environment;
+use Contao\Input;
+use Contao\PageModel;
+use Contao\PageTree;
+use Contao\StringUtil;
+use Contao\TextField;
+use Contao\Widget;
 use Hschottm\SurveyBundle\Export\Exporter;
 use Hschottm\SurveyBundle\Export\ExportHelper;
 
@@ -22,42 +31,42 @@ use Hschottm\SurveyBundle\Export\ExportHelper;
  * @copyright  Helmut Schottmüller 2009-2010
  * @author     Helmut Schottmüller <contao@aurealis.de>
  */
-class SurveyPINTAN extends \Backend
+class SurveyPINTAN extends Backend
 {
     protected $blnSave = true;
 
     public function exportTAN(DataContainer $dc)
     {
-        if ('exporttan' != \Input::get('key')) {
+        if ('exporttan' != Input::get('key')) {
             return '';
         }
 
-        if ('tl_survey_pin_tan' == \Input::get('table')) {
-            $this->redirect(\Backend::addToUrl('table=tl_survey', true, ['table']));
+        if ('tl_survey_pin_tan' == Input::get('table')) {
+            $this->redirect(Backend::addToUrl('table=tl_survey', true, ['table']));
 
             return;
         }
 
         $this->loadLanguageFile('tl_survey_pin_tan');
-        $this->Template = new \BackendTemplate('be_survey_export_tan');
+        $this->Template = new BackendTemplate('be_survey_export_tan');
 
         $this->Template->surveyPage = $this->getSurveyPageWidget();
 
-        $this->Template->hrefBack = \Backend::addToUrl('table=tl_survey_pin_tan', true, ['table', 'key']);
+        $this->Template->hrefBack = Backend::addToUrl('table=tl_survey_pin_tan', true, ['table', 'key']);
         $this->Template->goBack = $GLOBALS['TL_LANG']['MSC']['goBack'];
         $this->Template->headline = $GLOBALS['TL_LANG']['tl_survey_pin_tan']['exporttan'];
-        $this->Template->request = ampersand(str_replace('&id=', '&pid=', \Environment::get('request')));
-        $this->Template->submit = \StringUtil::specialchars($GLOBALS['TL_LANG']['tl_survey_pin_tan']['export']);
+        $this->Template->request = ampersand(str_replace('&id=', '&pid=', Environment::get('request')));
+        $this->Template->submit = StringUtil::specialchars($GLOBALS['TL_LANG']['tl_survey_pin_tan']['export']);
 
         // Create import form
-        if ('tl_export_survey_pin_tan' == \Input::post('FORM_SUBMIT') && $this->blnSave) {
+        if ('tl_export_survey_pin_tan' == Input::post('FORM_SUBMIT') && $this->blnSave) {
             $export = [];
             $surveyPage = $this->Template->surveyPage->value;
-            $pageModel = \PageModel::findOneBy('id', $surveyPage);
+            $pageModel = PageModel::findOneBy('id', $surveyPage);
             $pagedata = (null != $pageModel) ? $pageModel->row() : null;
-            $domain = \Environment::get('base');
+            $domain = Environment::get('base');
 
-            $res = \Hschottm\SurveyBundle\SurveyPinTanModel::findBy('pid', \Input::get('pid'), ['order' => 'tstamp DESC, id DESC']);
+            $res = \Hschottm\SurveyBundle\SurveyPinTanModel::findBy('pid', Input::get('pid'), ['order' => 'tstamp DESC, id DESC']);
             foreach ($res as $objPINTAN) {
                 $row = $objPINTAN->row();
                 $line = [];
@@ -168,7 +177,7 @@ class SurveyPINTAN extends \Backend
                     );
                     ++$intRowCounter;
                 }
-                $surveyModel = \Hschottm\SurveyBundle\SurveyModel::findOneBy('id', \Input::get('pid'));
+                $surveyModel = \Hschottm\SurveyBundle\SurveyModel::findOneBy('id', Input::get('pid'));
                 if (null != $surveyModel) {
                   $exporter->setFilename('TAN_'.$surveyModel->title);
                 } else {
@@ -177,7 +186,7 @@ class SurveyPINTAN extends \Backend
                 $exporter->sendFile("TAN", "TAN", "TAN", 'Contao CMS', 'Contao CMS');
                 exit;
             }
-            $this->redirect(\Backend::addToUrl('table=tl_survey_pin_tan', true, ['key', 'table']));
+            $this->redirect(Backend::addToUrl('table=tl_survey_pin_tan', true, ['key', 'table']));
         }
 
         return $this->Template->parse();
@@ -185,30 +194,30 @@ class SurveyPINTAN extends \Backend
 
     public function createTAN(DataContainer $dc)
     {
-        if ('createtan' != \Input::get('key')) {
+        if ('createtan' != Input::get('key')) {
             return '';
         }
 
         $this->loadLanguageFile('tl_survey_pin_tan');
-        $this->Template = new \BackendTemplate('be_survey_create_tan');
+        $this->Template = new BackendTemplate('be_survey_create_tan');
 
         $this->Template->nrOfTAN = $this->getTANWidget();
 
-        $this->Template->hrefBack = ampersand(str_replace('&key=createtan', '', \Environment::get('request')));
+        $this->Template->hrefBack = ampersand(str_replace('&key=createtan', '', Environment::get('request')));
         $this->Template->goBack = $GLOBALS['TL_LANG']['MSC']['goBack'];
         $this->Template->headline = $GLOBALS['TL_LANG']['tl_survey_pin_tan']['createtan'];
-        $this->Template->request = ampersand(\Environment::get('request'), ENCODE_AMPERSANDS);
-        $this->Template->submit = \StringUtil::specialchars($GLOBALS['TL_LANG']['tl_survey_pin_tan']['create']);
+        $this->Template->request = ampersand(Environment::get('request'), ENCODE_AMPERSANDS);
+        $this->Template->submit = StringUtil::specialchars($GLOBALS['TL_LANG']['tl_survey_pin_tan']['create']);
 
         // Create import form
-        if ('tl_export_survey_pin_tan' == \Input::post('FORM_SUBMIT') && $this->blnSave) {
+        if ('tl_export_survey_pin_tan' == Input::post('FORM_SUBMIT') && $this->blnSave) {
             $nrOfTAN = $this->Template->nrOfTAN->value;
             $this->import('\Hschottm\SurveyBundle\Survey', 'svy');
             for ($i = 0; $i < ceil($nrOfTAN); ++$i) {
                 $pintan = $this->svy->generatePIN_TAN();
-                $this->insertPinTan(\Input::get('id'), $pintan['PIN'], $pintan['TAN']);
+                $this->insertPinTan(Input::get('id'), $pintan['PIN'], $pintan['TAN']);
             }
-            $this->redirect(\Backend::addToUrl('', true, ['key']));
+            $this->redirect(Backend::addToUrl('', true, ['key']));
         }
 
         return $this->Template->parse();
@@ -234,13 +243,13 @@ class SurveyPINTAN extends \Backend
      */
     protected function getSurveyPageWidget($value = null)
     {
-        $widget = new \PageTree(\Widget::getAttributesFromDca($GLOBALS['TL_DCA']['tl_survey']['fields']['surveyPage'], 'surveyPage', $value, 'surveyPage', 'tl_survey'));
+        $widget = new PageTree(Widget::getAttributesFromDca($GLOBALS['TL_DCA']['tl_survey']['fields']['surveyPage'], 'surveyPage', $value, 'surveyPage', 'tl_survey'));
         if ($GLOBALS['TL_CONFIG']['showHelp'] && \strlen($GLOBALS['TL_LANG']['tl_survey']['surveyPage'][1])) {
             $widget->help = $GLOBALS['TL_LANG']['tl_survey']['surveyPage'][1];
         }
 
         // Valiate input
-        if ('tl_export_survey_pin_tan' == \Input::post('FORM_SUBMIT')) {
+        if ('tl_export_survey_pin_tan' == Input::post('FORM_SUBMIT')) {
             $widget->validate();
 
             if ($widget->hasErrors()) {
@@ -261,7 +270,7 @@ class SurveyPINTAN extends \Backend
      */
     protected function getTANWidget($value = null)
     {
-        $widget = new \TextField();
+        $widget = new TextField();
 
         $widget->id = 'nrOfTAN';
         $widget->name = 'nrOfTAN';
@@ -279,7 +288,7 @@ class SurveyPINTAN extends \Backend
         }
 
         // Valiate input
-        if ('tl_export_survey_pin_tan' == \Input::post('FORM_SUBMIT')) {
+        if ('tl_export_survey_pin_tan' == Input::post('FORM_SUBMIT')) {
             $widget->validate();
 
             if ($widget->hasErrors()) {

--- a/src/Resources/contao/classes/SurveyPagePreview.php
+++ b/src/Resources/contao/classes/SurveyPagePreview.php
@@ -10,7 +10,11 @@
 
 namespace Hschottm\SurveyBundle;
 
-class SurveyPagePreview extends \Backend
+use Contao\Backend;
+use Contao\FrontendTemplate;
+use Contao\StringUtil;
+
+class SurveyPagePreview extends Backend
 {
     /**
      * Import String library.
@@ -35,11 +39,11 @@ class SurveyPagePreview extends \Backend
         $surveyPageCollection = \Hschottm\SurveyBundle\SurveyPageModel::findBy(['pid=?', 'sorting<?'], [$row['pid'], $row['sorting']]);
         $position = (null != $surveyPageCollection) ? $surveyPageCollection->count() + 1 : 1;
 
-        $template = new \FrontendTemplate('be_survey_page_preview');
+        $template = new FrontendTemplate('be_survey_page_preview');
         $template->page = $GLOBALS['TL_LANG']['tl_survey_page']['page'];
         $template->position = $position;
-        $template->title = \StringUtil::specialchars($row['title']);
-        $template->description = \StringUtil::specialchars($row['description']);
+        $template->title = StringUtil::specialchars($row['title']);
+        $template->description = StringUtil::specialchars($row['description']);
 
         return $template->parse();
     }

--- a/src/Resources/contao/classes/SurveyQuestion.php
+++ b/src/Resources/contao/classes/SurveyQuestion.php
@@ -10,6 +10,10 @@
 
 namespace Hschottm\SurveyBundle;
 
+use Contao\Backend;
+use Contao\Database;
+use Contao\FrontendTemplate;
+
 /**
  * Class SurveyQuestion.
  *
@@ -18,7 +22,7 @@ namespace Hschottm\SurveyBundle;
  * @copyright  Helmut Schottmüller 2009-2010
  * @author     Helmut Schottmüller <contao@aurealis.de>
  */
-abstract class SurveyQuestion extends \Backend
+abstract class SurveyQuestion extends Backend
 {
     protected $arrData;
     protected $arrStatistics;
@@ -38,7 +42,7 @@ abstract class SurveyQuestion extends \Backend
         $this->arrStatistics['answered'] = 0;
         $this->arrStatistics['skipped'] = 0;
         if ($question_id > 0) {
-            $objQuestion = \Database::getInstance()->prepare('SELECT tl_survey_question.*, tl_survey_page.title pagetitle, tl_survey_page.pid parentID FROM tl_survey_question, tl_survey_page WHERE tl_survey_question.pid = tl_survey_page.id AND tl_survey_question.id = ?')
+            $objQuestion = Database::getInstance()->prepare('SELECT tl_survey_question.*, tl_survey_page.title pagetitle, tl_survey_page.pid parentID FROM tl_survey_question, tl_survey_page WHERE tl_survey_question.pid = tl_survey_page.id AND tl_survey_question.id = ?')
                 ->execute($question_id);
             if ($objQuestion->numRows) {
                 $this->data = $objQuestion->fetchAssoc();
@@ -93,7 +97,7 @@ abstract class SurveyQuestion extends \Backend
     public function getAnswersAsHTML()
     {
         if (\is_array($this->statistics['answers'])) {
-            $template = new \FrontendTemplate('survey_answers_default');
+            $template = new FrontendTemplate('survey_answers_default');
             $template->answers = $this->statistics['answers'];
 
             return $template->parse();

--- a/src/Resources/contao/classes/SurveyQuestionConstantsum.php
+++ b/src/Resources/contao/classes/SurveyQuestionConstantsum.php
@@ -10,6 +10,9 @@
 
 namespace Hschottm\SurveyBundle;
 
+use Contao\Database;
+use Contao\FrontendTemplate;
+use Contao\StringUtil;
 use Hschottm\SurveyBundle\Export\Exporter;
 
 /**
@@ -44,8 +47,8 @@ class SurveyQuestionConstantsum extends SurveyQuestion
     public function getAnswersAsHTML()
     {
         if (\is_array($this->statistics['cumulated'])) {
-            $template = new \FrontendTemplate('survey_answers_constantsum');
-            $template->choices = deserialize($this->arrData['sumchoices'], true);
+            $template = new FrontendTemplate('survey_answers_constantsum');
+            $template->choices = StringUtil::deserialize($this->arrData['sumchoices'], true);
             $template->summary = $GLOBALS['TL_LANG']['tl_survey_result']['cumulatedSummary'];
             $template->answer = $GLOBALS['TL_LANG']['tl_survey_result']['answer'];
             $template->nrOfSelections = $GLOBALS['TL_LANG']['tl_survey_result']['nrOfSelections'];
@@ -145,7 +148,7 @@ class SurveyQuestionConstantsum extends SurveyQuestion
     protected function calculateStatistics()
     {
         if (array_key_exists('id', $this->arrData) && array_key_exists('parentID', $this->arrData)) {
-            $objResult = \Database::getInstance()->prepare('SELECT * FROM tl_survey_result WHERE qid=? AND pid=?')
+            $objResult = Database::getInstance()->prepare('SELECT * FROM tl_survey_result WHERE qid=? AND pid=?')
                 ->execute($this->arrData['id'], $this->arrData['parentID']);
             if ($objResult->numRows) {
                 $this->calculateAnsweredSkipped($objResult);
@@ -192,7 +195,7 @@ class SurveyQuestionConstantsum extends SurveyQuestion
     {
         $this->choices = deserialize($this->arrData['sumchoices'], true);
         foreach ($this->choices as $k => $v) {
-            $this->choices[$k] = \StringUtil::decodeEntities($v);
+            $this->choices[$k] = StringUtil::decodeEntities($v);
         }
         $numcols = \count($this->choices);
         $result = [];
@@ -269,7 +272,7 @@ class SurveyQuestionConstantsum extends SurveyQuestion
 
         // question title
         $data = [
-          Exporter::DATA => \StringUtil::decodeEntities($this->title).($this->arrData['obligatory'] ? ' *' : ''),
+          Exporter::DATA => StringUtil::decodeEntities($this->title).($this->arrData['obligatory'] ? ' *' : ''),
           Exporter::CELLTYPE => Exporter::CELLTYPE_STRING,
           Exporter::ALIGNMENT => Exporter::ALIGNMENT_H_CENTER,
           Exporter::TEXTWRAP => true

--- a/src/Resources/contao/classes/SurveyQuestionMatrix.php
+++ b/src/Resources/contao/classes/SurveyQuestionMatrix.php
@@ -10,6 +10,9 @@
 
 namespace Hschottm\SurveyBundle;
 
+use Contao\Database;
+use Contao\FrontendTemplate;
+use Contao\StringUtil;
 use Hschottm\SurveyBundle\Export\Exporter;
 
 /**
@@ -45,7 +48,7 @@ class SurveyQuestionMatrix extends SurveyQuestion
     public function getAnswersAsHTML()
     {
         if (\is_array($this->statistics['cumulated'])) {
-            $template = new \FrontendTemplate('survey_answers_matrix');
+            $template = new FrontendTemplate('survey_answers_matrix');
             $template->choices = deserialize($this->arrData['matrixcolumns'], true);
             $template->rows = deserialize($this->arrData['matrixrows'], true);
             $template->statistics = $this->statistics;
@@ -153,7 +156,7 @@ class SurveyQuestionMatrix extends SurveyQuestion
     protected function calculateStatistics()
     {
         if (array_key_exists('id', $this->arrData) && array_key_exists('parentID', $this->arrData)) {
-            $objResult = \Database::getInstance()->prepare('SELECT * FROM tl_survey_result WHERE qid=? AND pid=?')
+            $objResult = Database::getInstance()->prepare('SELECT * FROM tl_survey_result WHERE qid=? AND pid=?')
                 ->execute($this->arrData['id'], $this->arrData['parentID']);
             if ($objResult->numRows) {
                 $this->calculateAnsweredSkipped($objResult);
@@ -202,7 +205,7 @@ class SurveyQuestionMatrix extends SurveyQuestion
     {
         $this->subquestions = deserialize($this->arrData['matrixrows'], true);
         foreach ($this->subquestions as $k => $v) {
-            $this->subquestions[$k] = \StringUtil::decodeEntities($v);
+            $this->subquestions[$k] = StringUtil::decodeEntities($v);
         }
         $numcols = \count($this->subquestions);
 
@@ -213,7 +216,7 @@ class SurveyQuestionMatrix extends SurveyQuestion
             $this->choices[] = '-';
         }
         foreach ($this->choices as $k => $v) {
-            $this->choices[$k] = \StringUtil::decodeEntities($v);
+            $this->choices[$k] = StringUtil::decodeEntities($v);
         }
 
         $result = [];
@@ -294,7 +297,7 @@ class SurveyQuestionMatrix extends SurveyQuestion
 
         // question title
         $data = [
-          Exporter::DATA => \StringUtil::decodeEntities($this->title).($this->arrData['obligatory'] ? ' *' : ''),
+          Exporter::DATA => StringUtil::decodeEntities($this->title).($this->arrData['obligatory'] ? ' *' : ''),
           Exporter::CELLTYPE => Exporter::CELLTYPE_STRING,
           Exporter::ALIGNMENT => Exporter::ALIGNMENT_H_CENTER,
           Exporter::TEXTWRAP => true

--- a/src/Resources/contao/classes/SurveyQuestionMultiplechoice.php
+++ b/src/Resources/contao/classes/SurveyQuestionMultiplechoice.php
@@ -10,6 +10,9 @@
 
 namespace Hschottm\SurveyBundle;
 
+use Contao\Database;
+use Contao\FrontendTemplate;
+use Contao\StringUtil;
 use Hschottm\SurveyBundle\Export\Exporter;
 
 /**
@@ -44,18 +47,18 @@ class SurveyQuestionMultiplechoice extends SurveyQuestion
     public function getAnswersAsHTML()
     {
         if (\is_array($this->statistics['cumulated'])) {
-            $template = new \FrontendTemplate('survey_answers_multiplechoice');
+            $template = new FrontendTemplate('survey_answers_multiplechoice');
             $template->statistics = $this->statistics;
             $template->summary = $GLOBALS['TL_LANG']['tl_survey_result']['cumulatedSummary'];
             $template->answer = $GLOBALS['TL_LANG']['tl_survey_result']['answer'];
             $template->nrOfSelections = $GLOBALS['TL_LANG']['tl_survey_result']['nrOfSelections'];
             $template->choices = (0 != strcmp($this->arrData['multiplechoice_subtype'], 'mc_dichotomous')) ? deserialize($this->arrData['choices'], true) : [0 => $GLOBALS['TL_LANG']['tl_survey_question']['yes'], 1 => $GLOBALS['TL_LANG']['tl_survey_question']['no']];
             $template->other = ($this->arrData['addother']) ? true : false;
-            $template->othertitle = \StringUtil::specialchars($this->arrData['othertitle']);
+            $template->othertitle = StringUtil::specialchars($this->arrData['othertitle']);
             $otherchoices = [];
             if (\count($this->statistics['cumulated']['other'])) {
                 foreach ($this->statistics['cumulated']['other'] as $value) {
-                    ++$otherchoices[\StringUtil::specialchars($value)];
+                    ++$otherchoices[StringUtil::specialchars($value)];
                 }
             }
             $template->otherchoices = $otherchoices;
@@ -155,7 +158,7 @@ class SurveyQuestionMultiplechoice extends SurveyQuestion
     protected function calculateStatistics()
     {
         if (array_key_exists('id', $this->arrData) && array_key_exists('parentID', $this->arrData)) {
-            $objResult = \Database::getInstance()->prepare('SELECT * FROM tl_survey_result WHERE qid=? AND pid=?')
+            $objResult = Database::getInstance()->prepare('SELECT * FROM tl_survey_result WHERE qid=? AND pid=?')
                 ->execute($this->arrData['id'], $this->arrData['parentID']);
             if ($objResult->numRows) {
                 $this->calculateAnsweredSkipped($objResult);
@@ -332,7 +335,7 @@ class SurveyQuestionMultiplechoice extends SurveyQuestion
 
         // question title
         $data = [
-          Exporter::DATA => \StringUtil::decodeEntities($this->title).($this->arrData['obligatory'] ? ' *' : ''),
+          Exporter::DATA => StringUtil::decodeEntities($this->title).($this->arrData['obligatory'] ? ' *' : ''),
           Exporter::CELLTYPE => Exporter::CELLTYPE_STRING,
           Exporter::ALIGNMENT => Exporter::ALIGNMENT_H_CENTER,
           Exporter::TEXTWRAP => true
@@ -424,7 +427,7 @@ class SurveyQuestionMultiplechoice extends SurveyQuestion
                     }
                     $strAnswer = (($emptyAnswer) ? ($arrAnswers['value'] . ' - ') : '') . $this->choices[$arrAnswers['value'] - 1];
                     if (($this->arrData['addother']) && ($arrAnswers['value'] == \count($this->choices))) {
-                        $strAnswer .= ': '.\StringUtil::decodeEntities($arrAnswers['other']);
+                        $strAnswer .= ': '.StringUtil::decodeEntities($arrAnswers['other']);
                     }
                     $exporter->setCellValue($sheet, $row, $col, [
                       Exporter::DATA => $strAnswer,
@@ -435,7 +438,7 @@ class SurveyQuestionMultiplechoice extends SurveyQuestion
                     foreach ($this->choices as $k => $v) {
                         $strAnswer = (\is_array($arrAnswers['value']) && array_key_exists($k + 1, $arrAnswers['value']))
                             ? ($this->arrData['addother'] && ($k + 1 == \count($this->choices)))
-                                ? \StringUtil::decodeEntities($arrAnswers['other'])
+                                ? StringUtil::decodeEntities($arrAnswers['other'])
                                 : 'x'
                             : '';
                         if (\strlen($strAnswer)) {

--- a/src/Resources/contao/classes/SurveyQuestionOpenended.php
+++ b/src/Resources/contao/classes/SurveyQuestionOpenended.php
@@ -10,6 +10,8 @@
 
 namespace Hschottm\SurveyBundle;
 
+use Contao\Database;
+use Contao\StringUtil;
 use Hschottm\SurveyBundle\Export\Exporter;
 
 /**
@@ -104,7 +106,7 @@ class SurveyQuestionOpenended extends SurveyQuestion
     protected function calculateStatistics()
     {
         if (array_key_exists('id', $this->arrData) && array_key_exists('parentID', $this->arrData)) {
-            $objResult = \Database::getInstance()->prepare('SELECT * FROM tl_survey_result WHERE qid=? AND pid=?')
+            $objResult = Database::getInstance()->prepare('SELECT * FROM tl_survey_result WHERE qid=? AND pid=?')
                 ->execute($this->arrData['id'], $this->arrData['parentID']);
             if ($objResult->numRows) {
                 $this->calculateAnsweredSkipped($objResult);
@@ -168,7 +170,7 @@ class SurveyQuestionOpenended extends SurveyQuestion
 
         // question title
         $exporter->setCellValue($sheet, $row++, $col, [
-          Exporter::DATA => \StringUtil::decodeEntities($this->title).($this->arrData['obligatory'] ? ' *' : ''),
+          Exporter::DATA => StringUtil::decodeEntities($this->title).($this->arrData['obligatory'] ? ' *' : ''),
           Exporter::CELLTYPE => Exporter::CELLTYPE_STRING,
           Exporter::ALIGNMENT => Exporter::ALIGNMENT_H_CENTER,
           Exporter::TEXTWRAP => true
@@ -215,7 +217,7 @@ class SurveyQuestionOpenended extends SurveyQuestion
                 $data = $this->statistics['participants'][$key][0]['result'];
             }
             if ($data) {
-                $data = \StringUtil::decodeEntities($data);
+                $data = StringUtil::decodeEntities($data);
                 $exporter->setCellValue($sheet, $row, $col, [
                   Exporter::DATA => $data,
                   Exporter::ALIGNMENT => Exporter::ALIGNMENT_H_CENTER,

--- a/src/Resources/contao/classes/SurveyQuestionPreview.php
+++ b/src/Resources/contao/classes/SurveyQuestionPreview.php
@@ -10,13 +10,17 @@
 
 namespace Hschottm\SurveyBundle;
 
+use Contao\Backend;
+use Contao\FrontendTemplate;
+use Contao\StringUtil;
+
 /**
  * Class SurveyQuestionPreview.
  *
  * @copyright  Helmut Schottmüller 2009-2010
  * @author     Helmut Schottmüller <contao@aurealis.de>
  */
-class SurveyQuestionPreview extends \Backend
+class SurveyQuestionPreview extends Backend
 {
     /**
      * Import String library.
@@ -46,11 +50,11 @@ class SurveyQuestionPreview extends \Backend
             $widget = $objWidget->generate();
         }
 
-        $template = new \FrontendTemplate('be_survey_question_preview');
+        $template = new FrontendTemplate('be_survey_question_preview');
         $template->hidetitle = $row['hidetitle'];
-        $template->help = \StringUtil::specialchars($row['help']);
+        $template->help = StringUtil::specialchars($row['help']);
         $template->questionNumber = $this->getQuestionNumber($row);
-        $template->title = \StringUtil::specialchars($row['title']);
+        $template->title = StringUtil::specialchars($row['title']);
         $template->obligatory = $row['obligatory'];
         $template->question = $row['question'];
         $return = $template->parse();

--- a/src/Resources/contao/classes/SurveyResultDetails.php
+++ b/src/Resources/contao/classes/SurveyResultDetails.php
@@ -10,7 +10,12 @@
 
 namespace Hschottm\SurveyBundle;
 
+use Contao\Backend;
+use Contao\BackendTemplate;
 use Contao\DataContainer;
+use Contao\Environment;
+use Contao\Input;
+use Contao\StringUtil;
 use Hschottm\SurveyBundle\Export\Exporter;
 use Hschottm\SurveyBundle\Export\ExportHelper;
 
@@ -22,7 +27,7 @@ use Hschottm\SurveyBundle\Export\ExportHelper;
  * @copyright  Helmut Schottmüller 2009-2018
  * @author     Helmut Schottmüller <https://github.com/hschottm>
  */
-class SurveyResultDetails extends \Backend
+class SurveyResultDetails extends Backend
 {
     protected $blnSave = true;
 
@@ -36,11 +41,11 @@ class SurveyResultDetails extends \Backend
 
     public function showDetails(DataContainer $dc)
     {
-        if ('details' != \Input::get('key')) {
+        if ('details' != Input::get('key')) {
             return '';
         }
         $return = '';
-        $qid = \Input::get('id');
+        $qid = Input::get('id');
         $qtype = $this->Database->prepare('SELECT questiontype, pid FROM tl_survey_question WHERE id = ?')
             ->execute($qid)
             ->fetchAssoc();
@@ -50,9 +55,9 @@ class SurveyResultDetails extends \Backend
         $class = 'Hschottm\\SurveyBundle\\SurveyQuestion'.ucfirst($qtype['questiontype']);
         $this->loadLanguageFile('tl_survey_result');
         $this->loadLanguageFile('tl_survey_question');
-        $this->Template = new \BackendTemplate('be_question_result_details');
+        $this->Template = new BackendTemplate('be_question_result_details');
         $this->Template->back = $GLOBALS['TL_LANG']['MSC']['goBack'];
-        $this->Template->hrefBack = \Backend::addToUrl('key=cumulated&amp;id='.$parent['pid'], true, ['key', 'id']);
+        $this->Template->hrefBack = Backend::addToUrl('key=cumulated&amp;id='.$parent['pid'], true, ['key', 'id']);
         if ($this->classFileExists($class)) {
             $this->import($class);
             $question = new $class($qid);
@@ -60,7 +65,7 @@ class SurveyResultDetails extends \Backend
             $this->Template->heading = sprintf($GLOBALS['TL_LANG']['tl_survey_result']['detailsHeading'], $qid);
             $data = [];
             array_push($data, ['key' => 'ID:', 'value' => $question->id, 'keyclass' => 'first', 'valueclass' => 'last']);
-            array_push($data, ['key' => $GLOBALS['TL_LANG']['tl_survey_question']['questiontype'][0].':', 'value' => \StringUtil::specialchars($GLOBALS['TL_LANG']['tl_survey_question'][$question->questiontype]), 'keyclass' => 'first tl_bg', 'valueclass' => 'last tl_bg']);
+            array_push($data, ['key' => $GLOBALS['TL_LANG']['tl_survey_question']['questiontype'][0].':', 'value' => StringUtil::specialchars($GLOBALS['TL_LANG']['tl_survey_question'][$question->questiontype]), 'keyclass' => 'first tl_bg', 'valueclass' => 'last tl_bg']);
             array_push($data, ['key' => $GLOBALS['TL_LANG']['tl_survey_question']['title'][0].':', 'value' => $question->title, 'keyclass' => 'first', 'valueclass' => 'last']);
             array_push($data, ['key' => $GLOBALS['TL_LANG']['tl_survey_question']['question'][0].':', 'value' => $question->question, 'keyclass' => 'first tl_bg', 'valueclass' => 'last tl_bg']);
             array_push($data, ['key' => $GLOBALS['TL_LANG']['tl_survey_question']['answered'].':', 'value' => $question->statistics['answered'], 'keyclass' => 'first', 'valueclass' => 'last']);
@@ -76,14 +81,14 @@ class SurveyResultDetails extends \Backend
 
     public function showCumulated(DataContainer $dc)
     {
-        if ('cumulated' != \Input::get('key')) {
+        if ('cumulated' != Input::get('key')) {
             return '';
         }
         $this->loadLanguageFile('tl_survey_result');
         $this->loadLanguageFile('tl_survey_question');
         $return = '';
         $objQuestion = $this->Database->prepare('SELECT tl_survey_question.*, tl_survey_page.title as pagetitle, tl_survey_page.pid as parentID FROM tl_survey_question, tl_survey_page WHERE tl_survey_question.pid = tl_survey_page.id AND tl_survey_page.pid = ? ORDER BY tl_survey_page.sorting, tl_survey_question.sorting')
-            ->execute(\Input::get('id'));
+            ->execute(Input::get('id'));
         $data = [];
         $abs_question_no = 0;
 
@@ -95,24 +100,24 @@ class SurveyResultDetails extends \Backend
                 $this->import($class);
                 $question = new $class();
                 $question->data = $row;
-                $strUrl = \Backend::addToUrl('key=details&amp;id='.$question->id, true, ['key', 'id']);
+                $strUrl = Backend::addToUrl('key=details&amp;id='.$question->id, true, ['key', 'id']);
                 array_push($data, [
                     'number' => $abs_question_no,
-                    'title' => \StringUtil::specialchars($row['title']),
-                    'type' => \StringUtil::specialchars($GLOBALS['TL_LANG']['tl_survey_question'][$row['questiontype']]),
+                    'title' => StringUtil::specialchars($row['title']),
+                    'type' => StringUtil::specialchars($GLOBALS['TL_LANG']['tl_survey_question'][$row['questiontype']]),
                     'answered' => $question->statistics['answered'],
                     'skipped' => $question->statistics['skipped'],
                     'hrefdetails' => $strUrl,
-                    'titledetails' => \StringUtil::specialchars(sprintf($GLOBALS['TL_LANG']['tl_survey_result']['details'][1], $question->id)),
+                    'titledetails' => StringUtil::specialchars(sprintf($GLOBALS['TL_LANG']['tl_survey_result']['details'][1], $question->id)),
                 ]);
             }
         }
-        $this->Template = new \BackendTemplate('be_survey_result_cumulated');
+        $this->Template = new BackendTemplate('be_survey_result_cumulated');
         $this->Template->back = $GLOBALS['TL_LANG']['MSC']['goBack'];
-        $this->Template->hrefBack = \Backend::addToUrl('', true, ['key', 'id']);
+        $this->Template->hrefBack = Backend::addToUrl('', true, ['key', 'id']);
         $this->Template->export = $GLOBALS['TL_LANG']['tl_survey_result']['export'];
-        $this->Template->hrefExport = \Backend::addToUrl('key=export&amp;id='.\Input::get('id'), true, ['key', 'id']);
-        $this->Template->heading = \StringUtil::specialchars($GLOBALS['TL_LANG']['tl_survey_result']['cumulatedResults']);
+        $this->Template->hrefExport = Backend::addToUrl('key=export&amp;id='.Input::get('id'), true, ['key', 'id']);
+        $this->Template->heading = StringUtil::specialchars($GLOBALS['TL_LANG']['tl_survey_result']['cumulatedResults']);
         $this->Template->summary = 'cumulated results';
         $this->Template->data = $data;
         $this->Template->imgdetails = 'bundles/hschottmsurvey/images/details.png';
@@ -124,12 +129,12 @@ class SurveyResultDetails extends \Backend
 
     public function exportResults(DataContainer $dc)
     {
-        if ('export' != \Input::get('key')) {
+        if ('export' != Input::get('key')) {
             return '';
         }
         $this->loadLanguageFile('tl_survey_result');
         $arrQuestions = $this->Database->prepare('SELECT tl_survey_question.*, tl_survey_page.title as pagetitle, tl_survey_page.pid as parentID FROM tl_survey_question, tl_survey_page WHERE tl_survey_question.pid = tl_survey_page.id AND tl_survey_page.pid = ? ORDER BY tl_survey_page.sorting, tl_survey_question.sorting')
-            ->execute(\Input::get('id'));
+            ->execute(Input::get('id'));
         if ($arrQuestions->numRows) {
             $exporter = ExportHelper::getExporter();
             $sheet = $GLOBALS['TL_LANG']['tl_survey_result']['cumulatedResults'];
@@ -147,7 +152,7 @@ class SurveyResultDetails extends \Backend
                 }
             }
 
-            $surveyModel = \Hschottm\SurveyBundle\SurveyModel::findOneBy('id', \Input::get('id'));
+            $surveyModel = \Hschottm\SurveyBundle\SurveyModel::findOneBy('id', Input::get('id'));
             if (null != $surveyModel) {
                 $filename = $surveyModel->title;
             } else {
@@ -156,7 +161,7 @@ class SurveyResultDetails extends \Backend
             $exporter->setFilename($filename);
             $exporter->sendFile($surveyModel->title, $surveyModel->title, $surveyModel->title, 'Contao CMS', 'Contao CMS');
         }
-        $href = \Backend::addToUrl('', true, ['key', 'id']);
+        $href = Backend::addToUrl('', true, ['key', 'id']);
         $this->redirect($href);
     }
 
@@ -175,11 +180,11 @@ class SurveyResultDetails extends \Backend
      */
     public function exportResultsRaw(DataContainer $dc)
     {
-        if ('exportraw' != \Input::get('key')) {
+        if ('exportraw' != Input::get('key')) {
             return '';
         }
 
-        $surveyID = \Input::get('id');
+        $surveyID = Input::get('id');
         $arrQuestions = $this->Database->prepare('
 				SELECT   tl_survey_question.*,
 				         tl_survey_page.title as pagetitle,
@@ -248,7 +253,7 @@ class SurveyResultDetails extends \Backend
             $exporter->sendFile($surveyModel->title, $surveyModel->title, $surveyModel->title, 'Contao CMS', 'Contao CMS');
             exit;
         }
-        $this->redirect(\Environment::get('script').'?do='.\Input::get('do'));
+        $this->redirect(Environment::get('script').'?do='.Input::get('do'));
     }
 
     /**

--- a/src/Resources/contao/dca/tl_content.php
+++ b/src/Resources/contao/dca/tl_content.php
@@ -8,6 +8,8 @@
  * @see	      https://github.com/hschottm/survey_ce
  */
 
+use Contao\DataContainer;
+
 $GLOBALS['TL_DCA']['tl_content']['palettes']['survey'] = '{type_legend},type,headline;{survey_legend},survey;{template_legend:hide},surveyTpl;{protected_legend:hide},protected;{expert_legend:hide},guests,cssID,space';
 
 $GLOBALS['TL_DCA']['tl_content']['fields']['survey'] = [

--- a/src/Resources/contao/dca/tl_survey.php
+++ b/src/Resources/contao/dca/tl_survey.php
@@ -8,7 +8,12 @@
  * @see	      https://github.com/hschottm/survey_ce
  */
 
- $found = (\strlen(\Input::get('id'))) ? \Hschottm\SurveyBundle\SurveyResultModel::findByPid(\Input::get('id')) : null;
+use Contao\Backend;
+use Contao\BackendUser;
+use Contao\Database;
+use Contao\Input;
+
+ $found = (\strlen(Input::get('id'))) ? \Hschottm\SurveyBundle\SurveyResultModel::findByPid(Input::get('id')) : null;
  $hasData = (null != $found && 0 < $found->count()) ? true : false;
 
 /*
@@ -548,8 +553,8 @@ class tl_survey extends Backend
   		$fields = array();
 
   		// Get all form fields which can be used to define recipient of confirmation mail
-  		$objFields = \Database::getInstance()->prepare("SELECT tl_survey_question.id,tl_survey_question.title FROM tl_survey_question, tl_survey_page WHERE tl_survey_question.pid = tl_survey_page.id AND tl_survey_page.pid = ? AND tl_survey_question.questiontype=? ORDER BY tl_survey_question.title ASC")
-  			->execute(\Input::get('id'), 'openended');
+  		$objFields = Database::getInstance()->prepare("SELECT tl_survey_question.id,tl_survey_question.title FROM tl_survey_question, tl_survey_page WHERE tl_survey_question.pid = tl_survey_page.id AND tl_survey_page.pid = ? AND tl_survey_question.questiontype=? ORDER BY tl_survey_question.title ASC")
+  			->execute(Input::get('id'), 'openended');
 
   		$fields[] = '-';
   		while ($objFields->next())

--- a/src/Resources/contao/dca/tl_survey_page.php
+++ b/src/Resources/contao/dca/tl_survey_page.php
@@ -8,7 +8,12 @@
  * @see	      https://github.com/hschottm/survey_ce
  */
 
- $found = (\strlen(\Input::get('id'))) ? \Hschottm\SurveyBundle\SurveyResultModel::findByPid(\Input::get('id')) : null;
+use Contao\Backend;
+use Contao\DataContainer;
+use Contao\Input;
+use Contao\StringUtil;
+
+ $found = (\strlen(Input::get('id'))) ? \Hschottm\SurveyBundle\SurveyResultModel::findByPid(Input::get('id')) : null;
  $hasData = (null != $found && 0 < $found->count()) ? true : false;
 
 if ($hasData) {
@@ -215,7 +220,7 @@ class tl_survey_page extends Backend
             return $this->generateImage(preg_replace('/\.svg$/i', '_.svg', $icon)).' ';
         }
 
-        return '<a href="'.$this->addToUrl($href.'&id='.$row['id']).'" title="'.\StringUtil::specialchars($title).'"'.$attributes.'>'.$this->generateImage($icon, $label).'</a> ';
+        return '<a href="'.$this->addToUrl($href.'&id='.$row['id']).'" title="'.StringUtil::specialchars($title).'"'.$attributes.'>'.$this->generateImage($icon, $label).'</a> ';
     }
 
     /**
@@ -242,7 +247,7 @@ class tl_survey_page extends Backend
             return $this->generateImage(preg_replace('/\.svg$/i', '_.svg', $icon)).' ';
         }
 
-        return '<a href="'.$this->addToUrl($href.'&id='.$row['id']).'" title="'.\StringUtil::specialchars($title).'"'.$attributes.'>'.$this->generateImage($icon, $label).'</a> ';
+        return '<a href="'.$this->addToUrl($href.'&id='.$row['id']).'" title="'.StringUtil::specialchars($title).'"'.$attributes.'>'.$this->generateImage($icon, $label).'</a> ';
     }
 
     /**
@@ -269,7 +274,7 @@ class tl_survey_page extends Backend
             return $this->generateImage(preg_replace('/\.svg$/i', '_.svg', $icon)).' ';
         }
 
-        return '<a href="'.$this->addToUrl($href.'&id='.$row['id']).'" title="'.\StringUtil::specialchars($title).'"'.$attributes.'>'.$this->generateImage($icon, $label).'</a> ';
+        return '<a href="'.$this->addToUrl($href.'&id='.$row['id']).'" title="'.StringUtil::specialchars($title).'"'.$attributes.'>'.$this->generateImage($icon, $label).'</a> ';
     }
 
     /**
@@ -296,13 +301,13 @@ class tl_survey_page extends Backend
             return $this->generateImage(preg_replace('/\.svg$/i', '_.svg', $icon)).' ';
         }
 
-        return '<a href="'.$this->addToUrl($href.'&id='.$row['id']).'" title="'.\StringUtil::specialchars($title).'"'.$attributes.'>'.$this->generateImage($icon, $label).'</a> ';
+        return '<a href="'.$this->addToUrl($href.'&id='.$row['id']).'" title="'.StringUtil::specialchars($title).'"'.$attributes.'>'.$this->generateImage($icon, $label).'</a> ';
     }
 
     protected function hasData()
     {
         if (null == $this->hasData) {
-          $resultModel = \Hschottm\SurveyBundle\SurveyResultModel::findBy(['pid=?'], [\Input::get('id')]);
+          $resultModel = \Hschottm\SurveyBundle\SurveyResultModel::findBy(['pid=?'], [Input::get('id')]);
           $this->hasData = null != $resultModel && $resultModel->count() > 0;
         }
 

--- a/src/Resources/contao/dca/tl_survey_participant.php
+++ b/src/Resources/contao/dca/tl_survey_participant.php
@@ -8,6 +8,10 @@
  * @see	      https://github.com/hschottm/survey_ce
  */
 
+use Contao\Backend;
+use Contao\Input;
+use Contao\System;
+
 $GLOBALS['TL_DCA']['tl_survey_participant'] = [
     // Config
     'config' => [
@@ -132,7 +136,7 @@ $GLOBALS['TL_DCA']['tl_survey_participant'] = [
  * @copyright  Helmut Schottmüller 2009
  * @author     Helmut Schottmüller <typolight@aurealis.de>
  */
-class tl_survey_participant extends \Backend
+class tl_survey_participant extends Backend
 {
     protected $pageCount;
 
@@ -143,7 +147,7 @@ class tl_survey_participant extends \Backend
      */
     public function checkPermission()
     {
-        switch (\Input::get('act')) {
+        switch (Input::get('act')) {
           case 'select':
           case 'show':
           case 'edit':
@@ -155,17 +159,17 @@ class tl_survey_participant extends \Backend
           case 'deleteAll':
           case 'overrideAll':
               /** @var Symfony\Component\HttpFoundation\Session\SessionInterface $objSession */
-              $objSession = \System::getContainer()->get('session');
+              $objSession = System::getContainer()->get('session');
               $session = $objSession->all();
-              $res = \Hschottm\SurveyBundle\SurveyParticipantModel::findBy('pid', \Input::get('id'));
+              $res = \Hschottm\SurveyBundle\SurveyParticipantModel::findBy('pid', Input::get('id'));
               if (null != $res && $res->count() >= 1) {
                   $session['CURRENT']['IDS'] = array_values($res->fetchEach('id'));
                   $objSession->replace($session);
               }
               break;
           default:
-              if (\strlen(\Input::get('act'))) {
-                  throw new Contao\CoreBundle\Exception\AccessDeniedException('Invalid command "'.\Input::get('act').'.');
+              if (\strlen(Input::get('act'))) {
+                  throw new Contao\CoreBundle\Exception\AccessDeniedException('Invalid command "'.Input::get('act').'.');
               }
               break;
       }

--- a/src/Resources/contao/dca/tl_survey_pin_tan.php
+++ b/src/Resources/contao/dca/tl_survey_pin_tan.php
@@ -8,6 +8,8 @@
  * @see	      https://github.com/hschottm/survey_ce
  */
 
+use Contao\Backend;
+
 $GLOBALS['TL_DCA']['tl_survey_pin_tan'] = [
     // Config
     'config' => [

--- a/src/Resources/contao/dca/tl_survey_question.php
+++ b/src/Resources/contao/dca/tl_survey_question.php
@@ -8,6 +8,13 @@
  * @see	      https://github.com/hschottm/survey_ce
  */
 
+use Contao\Backend;
+use Contao\BackendUser;
+use Contao\DataContainer;
+use Contao\Environment;
+use Contao\Input;
+use Contao\StringUtil;
+
 $GLOBALS['TL_DCA']['tl_survey_question'] = [
     // Config
     'config' => [
@@ -589,7 +596,7 @@ class tl_survey_question extends Backend
             ->limit(1)
             ->execute($dc->id);
         if (0 == strcmp($objQuestion->multiplechoice_subtype, 'mc_singleresponse')) {
-            return '<a class="tl_submit" style="margin-top: 10px;" href="'.$this->addToUrl('key=scale').'" title="'.\StringUtil::specialchars($GLOBALS['TL_LANG']['tl_survey_question']['addscale'][1]).'" onclick="Backend.getScrollOffset();">'.\StringUtil::specialchars($GLOBALS['TL_LANG']['tl_survey_question']['addscale'][0]).'</a>';
+            return '<a class="tl_submit" style="margin-top: 10px;" href="'.$this->addToUrl('key=scale').'" title="'.StringUtil::specialchars($GLOBALS['TL_LANG']['tl_survey_question']['addscale'][1]).'" onclick="Backend.getScrollOffset();">'.StringUtil::specialchars($GLOBALS['TL_LANG']['tl_survey_question']['addscale'][0]).'</a>';
         }
 
         return '';
@@ -604,7 +611,7 @@ class tl_survey_question extends Backend
      */
     public function addScale(DataContainer $dc)
     {
-        if ('scale' != \Input::get('key')) {
+        if ('scale' != Input::get('key')) {
             return '';
         }
 
@@ -621,28 +628,28 @@ class tl_survey_question extends Backend
         }
 
         // Add scale
-        if ('tl_add_scale' == \Input::post('FORM_SUBMIT')) {
-            if ((!\Input::post('scale') || 0 == strcmp(\Input::post('scale'), '-'))) {
+        if ('tl_add_scale' == Input::post('FORM_SUBMIT')) {
+            if ((!Input::post('scale') || 0 == strcmp(Input::post('scale'), '-'))) {
                 $_SESSION['TL_ERROR'][] = $GLOBALS['TL_LANG']['ERR']['selectoption'];
                 $this->reload();
             }
 
             $this->Database->prepare('UPDATE tl_survey_question SET choices=? WHERE id=?')
-                ->execute(serialize($arrScales[\Input::post('scale')]['scales']), $dc->id);
+                ->execute(serialize($arrScales[Input::post('scale')]['scales']), $dc->id);
 
             setcookie('BE_PAGE_OFFSET', 0, 0, '/');
-            $this->redirect(str_replace('&key=scale', '', \Environment::get('request')));
+            $this->redirect(str_replace('&key=scale', '', Environment::get('request')));
         }
 
         // Return form
         $result = '
 <div id="tl_buttons">
-<a href="'.ampersand(str_replace('&key=scale', '', \Environment::get('request'))).'" class="header_back" title="'.\StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['backBT']).'">'.$GLOBALS['TL_LANG']['MSC']['backBT'].'</a>
+<a href="'.ampersand(str_replace('&key=scale', '', Environment::get('request'))).'" class="header_back" title="'.StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['backBT']).'">'.$GLOBALS['TL_LANG']['MSC']['backBT'].'</a>
 </div>
 
 '.$this->getMessages().'
 
-<form action="'.ampersand(\Environment::get('request'), ENCODE_AMPERSANDS).'" id="tl_add_scale" class="tl_form" method="post">
+<form action="'.StringUtil::ampersand(Environment::get('request')).'" id="tl_add_scale" class="tl_form" method="post">
 <div class="tl_formbody_edit">
 <input type="hidden" name="FORM_SUBMIT" value="tl_add_scale" />
 <input type="hidden" name="REQUEST_TOKEN" value="'.REQUEST_TOKEN.'" />
@@ -658,9 +665,9 @@ class tl_survey_question extends Backend
                 if (\strlen($lastfolder)) {
                     $result .= '</optgroup>';
                 }
-                $result .= '<optgroup label="'.\StringUtil::specialchars($scale['folder']).'">';
+                $result .= '<optgroup label="'.StringUtil::specialchars($scale['folder']).'">';
             }
-            $result .= '<option value="'.\StringUtil::specialchars($id).'">'.\StringUtil::specialchars($scale['title']).'</option>\n';
+            $result .= '<option value="'.StringUtil::specialchars($id).'">'.StringUtil::specialchars($scale['title']).'</option>\n';
             $lastfolder = $scale['folder'];
         }
         $result .= '</optgroup>';
@@ -674,7 +681,7 @@ class tl_survey_question extends Backend
 <div class="tl_formbody_submit">
 
 <div class="tl_submit_container">
-<input type="submit" name="save" id="save" class="tl_submit" alt="add scale" accesskey="s" value="'.\StringUtil::specialchars($GLOBALS['TL_LANG']['tl_survey_question']['save_add_scale']).'" />
+<input type="submit" name="save" id="save" class="tl_submit" alt="add scale" accesskey="s" value="'.StringUtil::specialchars($GLOBALS['TL_LANG']['tl_survey_question']['save_add_scale']).'" />
 </div>
 
 </div>

--- a/src/Resources/contao/dca/tl_survey_scale.php
+++ b/src/Resources/contao/dca/tl_survey_scale.php
@@ -8,6 +8,9 @@
  * @see	      https://github.com/hschottm/survey_ce
  */
 
+use Contao\Backend;
+use Contao\StringUtil;
+
 $GLOBALS['TL_DCA']['tl_survey_scale'] = [
     // Config
     'config' => [
@@ -152,7 +155,7 @@ class tl_survey_scale extends Backend
         $result .= '<ol>';
         $answers = deserialize($row['scale'], true);
         foreach ($answers as $answer) {
-            $result .= '<li>'.\StringUtil::specialchars($answer).'</li>';
+            $result .= '<li>'.StringUtil::specialchars($answer).'</li>';
         }
         $result .= '</ol>';
 

--- a/src/Resources/contao/dca/tl_survey_scale_folder.php
+++ b/src/Resources/contao/dca/tl_survey_scale_folder.php
@@ -102,15 +102,3 @@ $GLOBALS['TL_DCA']['tl_survey_scale_folder'] = [
         ],
     ],
 ];
-
-/**
- * Class tl_survey_scale_folder.
- *
- * Provide miscellaneous methods that are used by the data configuration array.
- *
- * @copyright  Helmut Schottmüller 2009
- * @author     Helmut Schottmüller <typolight@aurealis.de>
- */
-class tl_survey_scale_folder extends Backend
-{
-}

--- a/src/Resources/contao/elements/ContentSurvey.php
+++ b/src/Resources/contao/elements/ContentSurvey.php
@@ -18,6 +18,7 @@ use Contao\File;
 use Contao\FilesModel;
 use Contao\FrontendTemplate;
 use Contao\Input;
+use Contao\PageModel;
 use Contao\StringUtil;
 use Contao\Validator;
 

--- a/src/Resources/contao/elements/ContentSurvey.php
+++ b/src/Resources/contao/elements/ContentSurvey.php
@@ -10,7 +10,18 @@
 
 namespace Hschottm\SurveyBundle;
 
-class ContentSurvey extends \ContentElement
+use Contao\BackendTemplate;
+use Contao\ContentElement;
+use Contao\Email;
+use Contao\Environment;
+use Contao\File;
+use Contao\FilesModel;
+use Contao\FrontendTemplate;
+use Contao\Input;
+use Contao\StringUtil;
+use Contao\Validator;
+
+class ContentSurvey extends ContentElement
 {
     /**
      * Template.
@@ -31,7 +42,7 @@ class ContentSurvey extends \ContentElement
     public function generate()
     {
         if (TL_MODE == 'BE') {
-            $objTemplate = new \BackendTemplate('be_wildcard');
+            $objTemplate = new BackendTemplate('be_wildcard');
             $objTemplate->wildcard = '### SURVEY ###';
 
             return $objTemplate->parse();
@@ -61,7 +72,7 @@ class ContentSurvey extends \ContentElement
             $GLOBALS['TL_JAVASCRIPT'] = ['bundles/hschottmsurvey/js/survey.js'];
         }
 
-        $surveyID = (\strlen(\Input::post('survey'))) ? \Input::post('survey') : $this->survey;
+        $surveyID = (\strlen(Input::post('survey'))) ? Input::post('survey') : $this->survey;
 
         $this->objSurvey = $this->Database->prepare('SELECT * FROM tl_survey WHERE id=?')
             ->execute($surveyID);
@@ -93,13 +104,13 @@ class ContentSurvey extends \ContentElement
             $pages = $pages->fetchAll();
         }
 
-        $page = (\Input::post('page')) ? \Input::post('page') : 0;
+        $page = (Input::post('page')) ? Input::post('page') : 0;
         // introduction page / status
         if (0 == $page) {
             $this->outIntroductionPage();
         }
         // check survey start
-        if (\Input::post('start') || (1 == $this->objSurvey->immediate_start && !\Input::post('FORM_SUBMIT'))) {
+        if (Input::post('start') || (1 == $this->objSurvey->immediate_start && !Input::post('FORM_SUBMIT'))) {
             $page = 0;
             switch ($this->objSurvey->access) {
                 case 'anon':
@@ -118,8 +129,8 @@ class ContentSurvey extends \ContentElement
                     }
                     break;
                 case 'anoncode':
-                    $tan = \Input::post('tan');
-                    if ((0 == strcmp(\Input::post('FORM_SUBMIT'), 'tl_survey_form')) && (\strlen($tan))) {
+                    $tan = Input::post('tan');
+                    if ((0 == strcmp(Input::post('FORM_SUBMIT'), 'tl_survey_form')) && (\strlen($tan))) {
                         $result = $this->svy->checkPINTAN($this->objSurvey->id, '', $tan);
                         if (false === $result) {
                             $this->Template->tanMsg = $GLOBALS['TL_LANG']['ERR']['survey_wrong_tan'];
@@ -169,8 +180,8 @@ class ContentSurvey extends \ContentElement
         // check question input and save input or return a question list of the page
         $surveypage = [];
         if (($page > 0 && $page <= \count($pages))) {
-            if ('tl_survey' == \Input::post('FORM_SUBMIT')) {
-                $goback = (\strlen(\Input::post('prev'))) ? true : false;
+            if ('tl_survey' == Input::post('FORM_SUBMIT')) {
+                $goback = (\strlen(Input::post('prev'))) ? true : false;
                 $surveypage = $this->createSurveyPage($pages[$page - 1], $page, true, $goback);
             }
         }
@@ -178,7 +189,7 @@ class ContentSurvey extends \ContentElement
         // submit successful, calculate next page and return a question list of the new page
         $previouspage = $page;
         if (0 == \count($surveypage)) {
-            if (\strlen(\Input::post('next'))) {
+            if (\strlen(Input::post('next'))) {
                 $pageid = $this->evaluateConditions($pages[$page-1]);
                 if (null == $pageid)
                 {
@@ -196,10 +207,10 @@ class ContentSurvey extends \ContentElement
                 }
                 $this->insertNavigation($this->objSurvey->id, $this->pin, $this->User->id, $previouspage, $page);
             }
-            if (\strlen(\Input::post('finish'))) {
+            if (\strlen(Input::post('finish'))) {
                 $page++;
             }
-            if (\strlen(\Input::post('prev'))) {
+            if (\strlen(Input::post('prev'))) {
                 $res = \Hschottm\SurveyBundle\SurveyNavigationModel::findOneBy(['pid=?', 'pin=?', 'uid=?', 'topage=?'], [$this->objSurvey->id, $this->pin, (strlen($this->User->id) == 0) ? 0 : $this->User->id, $page], ['order' => 'tstamp DESC']);
                 if (null != $res) {
                   $page = $res->frompage;
@@ -223,7 +234,7 @@ class ContentSurvey extends \ContentElement
                 $this->questionblock_template = $pages[$page - 1]['page_template'];
             }
         }
-        $questionBlockTemplate = new \FrontEndTemplate($this->questionblock_template);
+        $questionBlockTemplate = new FrontendTemplate($this->questionblock_template);
         $questionBlockTemplate->surveypage = $surveypage;
                 if (is_array($pages))
                 {
@@ -242,8 +253,8 @@ class ContentSurvey extends \ContentElement
         $this->Template->survey_id = $this->objSurvey->id;
         $this->Template->show_title = $this->objSurvey->show_title;
         $this->Template->show_cancel = ($page > 0 && \count($surveypage)) ? $this->objSurvey->show_cancel : false;
-        $this->Template->surveytitle = \StringUtil::specialchars($this->objSurvey->title);
-        $this->Template->cancel = \StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['cancel_survey']);
+        $this->Template->surveytitle = StringUtil::specialchars($this->objSurvey->title);
+        $this->Template->cancel = StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['cancel_survey']);
         global $objPage;
         $this->Template->cancellink = $this->generateFrontendUrl($objPage->row());
         $this->Template->allowback = $this->objSurvey->allowback;
@@ -257,7 +268,7 @@ class ContentSurvey extends \ContentElement
 	$this->Template->page = $page;
         $this->Template->introduction = $this->objSurvey->introduction;
         $this->Template->finalsubmission = ($this->objSurvey->finalsubmission) ? $this->objSurvey->finalsubmission : $GLOBALS['TL_LANG']['MSC']['survey_finalsubmission'];
-        $formaction = \Environment::get('request');
+        $formaction = Environment::get('request');
 
         $this->Template->pageXofY = $GLOBALS['TL_LANG']['MSC']['page_x_of_y'];
         $this->Template->next = $GLOBALS['TL_LANG']['MSC']['survey_next'];
@@ -364,7 +375,7 @@ class ContentSurvey extends \ContentElement
     {
         $this->questionpositions = [];
         if (!\strlen($this->pin)) {
-            $this->pin = \Input::post('pin');
+            $this->pin = Input::post('pin');
         }
         $surveypage = [];
         $pagequestioncounter = 1;
@@ -432,7 +443,7 @@ class ContentSurvey extends \ContentElement
             }
         }
 
-        if ($validate && 'tl_survey' == \Input::post('FORM_SUBMIT') && !\strlen($this->pin)) {
+        if ($validate && 'tl_survey' == Input::post('FORM_SUBMIT') && !\strlen($this->pin)) {
             if ($this->objSurvey->usecookie && \strlen($_COOKIE['TLsvy_'.$this->objSurvey->id])) {
                 // restore lost PIN from cookie
                 $this->pin = $_COOKIE['TLsvy_'.$this->objSurvey->id];
@@ -444,7 +455,7 @@ class ContentSurvey extends \ContentElement
         }
 
         // save survey values
-        if ($validate && 'tl_survey' == \Input::post('FORM_SUBMIT') && (!$doNotSubmit || $goback)) {
+        if ($validate && 'tl_survey' == Input::post('FORM_SUBMIT') && (!$doNotSubmit || $goback)) {
             if (!\strlen($this->pin) || !$this->isValid($this->pin)) {
                 global $objPage;
                 $this->redirect($this->generateFrontendUrl($objPage->row()));
@@ -497,7 +508,7 @@ class ContentSurvey extends \ContentElement
                 }
             }
 
-            if (\Input::post('finish')) {
+            if (Input::post('finish')) {
                 // finish the survey
                 switch ($this->objSurvey->access) {
                     case 'anon':
@@ -533,14 +544,14 @@ class ContentSurvey extends \ContentElement
         					$objMailProperties->attachments = array();
 
         					// Set the sender as given in form configuration
-        					list($senderName, $sender) = \StringUtil::splitFriendlyEmail($this->objSurvey->confirmationMailSender);
+        					list($senderName, $sender) = StringUtil::splitFriendlyEmail($this->objSurvey->confirmationMailSender);
         					$objMailProperties->sender = $sender;
         					$objMailProperties->senderName = $senderName;
 
         					// Set the 'reply to' address, if given in form configuration
         					if (!empty($this->objSurvey->confirmationMailReplyto))
         					{
-        						list($replyToName, $replyTo) = \StringUtil::splitFriendlyEmail($this->objSurvey->confirmationMailReplyto);
+        						list($replyToName, $replyTo) = StringUtil::splitFriendlyEmail($this->objSurvey->confirmationMailReplyto);
         						$objMailProperties->replyTo = (strlen($replyToName) ? $replyToName . ' <' . $replyTo . '>' : $replyTo);
         					}
 
@@ -567,7 +578,7 @@ class ContentSurvey extends \ContentElement
         					{
         						foreach ($arrRecipient as $kR => $recipient)
         						{
-        							list($recipientName, $recipient) = \StringUtil::splitFriendlyEmail($this->replaceInsertTags($recipient, false));
+        							list($recipientName, $recipient) = StringUtil::splitFriendlyEmail($this->replaceInsertTags($recipient, false));
         							$arrRecipient[$kR] = (strlen($recipientName) ? $recipientName . ' <' . $recipient . '>' : $recipient);
         						}
         					}
@@ -583,11 +594,11 @@ class ContentSurvey extends \ContentElement
         							{
         								foreach ($arrCustomAttachments as $varFile)
         								{
-        									$objFileModel = \FilesModel::findById($varFile);
+        									$objFileModel = FilesModel::findById($varFile);
 
         									if ($objFileModel != null)
         									{
-        										$objFile = new \File($objFileModel->path);
+        										$objFile = new File($objFileModel->path);
         										if ($objFile->size)
         										{
         											$objMailProperties->attachments[TL_ROOT .'/' . $objFile->path] = array
@@ -602,13 +613,13 @@ class ContentSurvey extends \ContentElement
         						}
         					}
 
-        					$objMailProperties->subject = \StringUtil::decodeEntities($this->objSurvey->confirmationMailSubject);
-        					$objMailProperties->messageText = \StringUtil::decodeEntities($this->objSurvey->confirmationMailText);
+        					$objMailProperties->subject = StringUtil::decodeEntities($this->objSurvey->confirmationMailSubject);
+        					$objMailProperties->messageText = StringUtil::decodeEntities($this->objSurvey->confirmationMailText);
 
         					$messageHtmlTmpl = '';
-        					if (\Validator::isUuid($this->objSurvey->confirmationMailTemplate) || (is_numeric($this->objSurvey->confirmationMailTemplate) && $this->objSurvey->confirmationMailTemplate > 0))
+        					if (Validator::isUuid($this->objSurvey->confirmationMailTemplate) || (is_numeric($this->objSurvey->confirmationMailTemplate) && $this->objSurvey->confirmationMailTemplate > 0))
         					{
-        						$objFileModel = \FilesModel::findById($this->objSurvey->confirmationMailTemplate);
+        						$objFileModel = FilesModel::findById($this->objSurvey->confirmationMailTemplate);
         						if ($objFileModel != null)
         						{
         							$messageHtmlTmpl = $objFileModel->path;
@@ -616,7 +627,7 @@ class ContentSurvey extends \ContentElement
         					}
         					if ($messageHtmlTmpl != '')
         					{
-        						$fileTemplate = new \File($messageHtmlTmpl);
+        						$fileTemplate = new File($messageHtmlTmpl);
         						if ($fileTemplate->mime == 'text/html')
         						{
         							$messageHtml = $fileTemplate->getContent();
@@ -630,7 +641,7 @@ class ContentSurvey extends \ContentElement
         					$blnConfirmationSent = false;
         					if (!empty($objMailProperties->recipients))
         					{
-        						$objMail = new \Email();
+        						$objMail = new Email();
         						$objMail->from = $objMailProperties->sender;
 
         						if (!empty($objMailProperties->senderName))
@@ -679,7 +690,7 @@ class ContentSurvey extends \ContentElement
                   $condition = true;
                   if ($this->objSurvey->confirmationMailAlternateCondition)
                   {
-                    if ($helper->replaceTags(sprintf("{if %s}1{endif}", \StringUtil::decodeEntities($this->objSurvey->confirmationMailAlternateCondition)), $this->pin, []) == '1')
+                    if ($helper->replaceTags(sprintf("{if %s}1{endif}", StringUtil::decodeEntities($this->objSurvey->confirmationMailAlternateCondition)), $this->pin, []) == '1')
                     {
                       $condition = true;
                     }
@@ -700,14 +711,14 @@ class ContentSurvey extends \ContentElement
           					$objMailProperties->attachments = array();
 
           					// Set the sender as given in form configuration
-          					list($senderName, $sender) = \StringUtil::splitFriendlyEmail($this->objSurvey->confirmationMailAlternateSender);
+          					list($senderName, $sender) = StringUtil::splitFriendlyEmail($this->objSurvey->confirmationMailAlternateSender);
           					$objMailProperties->sender = $sender;
           					$objMailProperties->senderName = $senderName;
 
           					// Set the 'reply to' address, if given in form configuration
           					if (!empty($this->objSurvey->confirmationMailAlternateReplyto))
           					{
-          						list($replyToName, $replyTo) = \StringUtil::splitFriendlyEmail($this->objSurvey->confirmationMailAlternateReplyto);
+          						list($replyToName, $replyTo) = StringUtil::splitFriendlyEmail($this->objSurvey->confirmationMailAlternateReplyto);
           						$objMailProperties->replyTo = (strlen($replyToName) ? $replyToName . ' <' . $replyTo . '>' : $replyTo);
           					}
 
@@ -724,7 +735,7 @@ class ContentSurvey extends \ContentElement
           					{
           						foreach ($arrRecipient as $kR => $recipient)
           						{
-          							list($recipientName, $recipient) = \StringUtil::splitFriendlyEmail($this->replaceInsertTags($recipient, false));
+          							list($recipientName, $recipient) = StringUtil::splitFriendlyEmail($this->replaceInsertTags($recipient, false));
           							$arrRecipient[$kR] = (strlen($recipientName) ? $recipientName . ' <' . $recipient . '>' : $recipient);
           						}
           					}
@@ -740,11 +751,11 @@ class ContentSurvey extends \ContentElement
           							{
           								foreach ($arrCustomAttachments as $varFile)
           								{
-          									$objFileModel = \FilesModel::findById($varFile);
+          									$objFileModel = FilesModel::findById($varFile);
 
           									if ($objFileModel != null)
           									{
-          										$objFile = new \File($objFileModel->path);
+          										$objFile = new File($objFileModel->path);
           										if ($objFile->size)
           										{
           											$objMailProperties->attachments[TL_ROOT .'/' . $objFile->path] = array
@@ -759,13 +770,13 @@ class ContentSurvey extends \ContentElement
           						}
           					}
 
-          					$objMailProperties->subject = \StringUtil::decodeEntities($this->objSurvey->confirmationMailAlternateSubject);
-          					$objMailProperties->messageText = \StringUtil::decodeEntities($this->objSurvey->confirmationMailAlternateText);
+          					$objMailProperties->subject = StringUtil::decodeEntities($this->objSurvey->confirmationMailAlternateSubject);
+          					$objMailProperties->messageText = StringUtil::decodeEntities($this->objSurvey->confirmationMailAlternateText);
 
           					$messageHtmlTmpl = '';
-          					if (\Validator::isUuid($this->objSurvey->confirmationMailAlternateTemplate) || (is_numeric($this->objSurvey->confirmationMailAlternateTemplate) && $this->objSurvey->confirmationMailAlternateTemplate > 0))
+          					if (Validator::isUuid($this->objSurvey->confirmationMailAlternateTemplate) || (is_numeric($this->objSurvey->confirmationMailAlternateTemplate) && $this->objSurvey->confirmationMailAlternateTemplate > 0))
           					{
-          						$objFileModel = \FilesModel::findById($this->objSurvey->confirmationMailAlternateTemplate);
+          						$objFileModel = FilesModel::findById($this->objSurvey->confirmationMailAlternateTemplate);
           						if ($objFileModel != null)
           						{
           							$messageHtmlTmpl = $objFileModel->path;
@@ -773,7 +784,7 @@ class ContentSurvey extends \ContentElement
           					}
           					if ($messageHtmlTmpl != '')
           					{
-          						$fileTemplate = new \File($messageHtmlTmpl);
+          						$fileTemplate = new File($messageHtmlTmpl);
           						if ($fileTemplate->mime == 'text/html')
           						{
           							$messageHtml = $fileTemplate->getContent();
@@ -787,7 +798,7 @@ class ContentSurvey extends \ContentElement
           					$blnConfirmationSent = false;
           					if (!empty($objMailProperties->recipients))
           					{
-          						$objMail = new \Email();
+          						$objMail = new Email();
           						$objMail->from = $objMailProperties->sender;
 
           						if (!empty($objMailProperties->senderName))
@@ -833,7 +844,7 @@ class ContentSurvey extends \ContentElement
                 }
 
                 if ($this->objSurvey->jumpto) {
-                    $pagedata = \PageModel::findByPk($this->objSurvey->jumpto);
+                    $pagedata = PageModel::findByPk($this->objSurvey->jumpto);
                     if (null != $pagedata) {
                         $this->redirect($pagedata->getFrontendUrl());
                     }
@@ -901,8 +912,8 @@ class ContentSurvey extends \ContentElement
                 $this->Template->needsTAN = true;
                 $this->Template->txtTANInputDesc = $GLOBALS['TL_LANG']['tl_content']['enter_tan_to_start_desc'];
                 $this->Template->txtTANInput = $GLOBALS['TL_LANG']['tl_content']['enter_tan_to_start'];
-                if (\strlen(\Input::get('code'))) {
-                    $this->Template->tancode = \Input::get('code');
+                if (\strlen(Input::get('code'))) {
+                    $this->Template->tancode = Input::get('code');
                 }
                 break;
             case 'nonanoncode':

--- a/src/Resources/contao/forms/FormConstantSumQuestion.php
+++ b/src/Resources/contao/forms/FormConstantSumQuestion.php
@@ -10,6 +10,9 @@
 
 namespace Hschottm\SurveyBundle;
 
+use Contao\FrontendTemplate;
+use Contao\StringUtil;
+
 /**
  * Class FormConstantSumQuestion.
  *
@@ -93,11 +96,11 @@ class FormConstantSumQuestion extends FormQuestionWidget
     public function generate()
     {
         $this->loadLanguageFile('tl_survey_question');
-        $template = new \FrontendTemplate('survey_question_constantsum');
+        $template = new FrontendTemplate('survey_question_constantsum');
         $template->choices = $this->arrChoices;
         $template->blnInputFirst = $this->blnInputFirst;
-        $template->name = \StringUtil::specialchars($this->strName);
-        $template->ctrl_id = \StringUtil::specialchars($this->strId);
+        $template->name = StringUtil::specialchars($this->strName);
+        $template->ctrl_id = StringUtil::specialchars($this->strId);
         $template->ctrl_class = (\strlen($this->strClass) ? ' '.$this->strClass : '');
         $template->values = $this->varValue;
         $widget = $template->parse();

--- a/src/Resources/contao/forms/FormMatrixQuestion.php
+++ b/src/Resources/contao/forms/FormMatrixQuestion.php
@@ -10,6 +10,9 @@
 
 namespace Hschottm\SurveyBundle;
 
+use Contao\FrontendTemplate;
+use Contao\StringUtil;
+
 /**
  * Class FormMatrixQuestion.
  *
@@ -127,7 +130,7 @@ class FormMatrixQuestion extends FormQuestionWidget
         if ($this->blnNeutralColumn) {
             $col_classes['neutral'] = substr(standardize($this->strNeutralColumn), 0, 28);
         }
-        $template = new \FrontendTemplate('survey_question_matrix');
+        $template = new FrontendTemplate('survey_question_matrix');
         $template->nrOfColumns = max(1, \count($this->arrColumns)) + (($this->blnNeutralColumn) ? 1 : 0) + (($this->blnBipolar && 0 == strcmp($this->strBipolarPosition, 'aside')) ? 2 : 0);
         $template->columns = $this->arrColumns;
         $template->col_classes = $col_classes;
@@ -137,14 +140,14 @@ class FormMatrixQuestion extends FormQuestionWidget
         $template->bipolar = $this->blnBipolar;
         $template->bipolarTop = 0 == strcmp($this->strBipolarPosition, 'top');
         $template->bipolarAside = 0 == strcmp($this->strBipolarPosition, 'aside');
-        $template->leftadjective = \StringUtil::specialchars($this->strAdjective1);
-        $template->rightadjective = \StringUtil::specialchars($this->strAdjective2);
+        $template->leftadjective = StringUtil::specialchars($this->strAdjective1);
+        $template->rightadjective = StringUtil::specialchars($this->strAdjective2);
         $template->hasNeutralColumn = $this->blnNeutralColumn;
-        $template->neutralColumn = \StringUtil::specialchars($this->strNeutralColumn);
+        $template->neutralColumn = StringUtil::specialchars($this->strNeutralColumn);
         $template->singleResponse = 0 == strcmp($this->questiontype, 'matrix_singleresponse');
         $template->multipleResponse = !$template->singleResponse;
-        $template->ctrl_name = \StringUtil::specialchars($this->strName);
-        $template->ctrl_id = \StringUtil::specialchars($this->strId);
+        $template->ctrl_name = StringUtil::specialchars($this->strName);
+        $template->ctrl_id = StringUtil::specialchars($this->strId);
         $template->ctrl_class = (\strlen($this->strClass) ? ' '.$this->strClass : '');
         $template->values = $this->varValue;
         $widget = $template->parse();

--- a/src/Resources/contao/forms/FormMultipleChoiceQuestion.php
+++ b/src/Resources/contao/forms/FormMultipleChoiceQuestion.php
@@ -10,6 +10,9 @@
 
 namespace Hschottm\SurveyBundle;
 
+use Contao\FrontendTemplate;
+use Contao\StringUtil;
+
 /**
  * Class FormMultipleChoiceQuestion.
  *
@@ -119,9 +122,9 @@ class FormMultipleChoiceQuestion extends FormQuestionWidget
         $strOptions = '';
 
         $this->loadLanguageFile('tl_survey_question');
-        $template = new \FrontendTemplate('survey_question_multiplechoice');
-        $template->ctrl_name = \StringUtil::specialchars($this->strName);
-        $template->ctrl_id = \StringUtil::specialchars($this->strId);
+        $template = new FrontendTemplate('survey_question_multiplechoice');
+        $template->ctrl_name = StringUtil::specialchars($this->strName);
+        $template->ctrl_id = StringUtil::specialchars($this->strId);
         $template->ctrl_class = (\strlen($this->strClass) ? ' '.$this->strClass : '');
         $template->singleResponse = 0 == strcmp($this->questiontype, 'mc_singleresponse');
         $template->multipleResponse = 0 == strcmp($this->questiontype, 'mc_multipleresponse');
@@ -134,7 +137,7 @@ class FormMultipleChoiceQuestion extends FormQuestionWidget
         $template->blnOther = $this->blnOther;
         $template->lngYes = $GLOBALS['TL_LANG']['tl_survey_question']['yes'];
         $template->lngNo = $GLOBALS['TL_LANG']['tl_survey_question']['no'];
-        $template->otherTitle = \StringUtil::specialchars($this->strOtherTitle);
+        $template->otherTitle = StringUtil::specialchars($this->strOtherTitle);
         $strOptions = $template->parse();
         $strError = $this->getErrorAsHTML();
 

--- a/src/Resources/contao/forms/FormOpenEndedQuestion.php
+++ b/src/Resources/contao/forms/FormOpenEndedQuestion.php
@@ -10,6 +10,10 @@
 
 namespace Hschottm\SurveyBundle;
 
+use Contao\Date;
+use Contao\FrontendTemplate;
+use Contao\StringUtil;
+
 /**
  * Class FormOpenEndedQuestion.
  *
@@ -124,9 +128,9 @@ class FormOpenEndedQuestion extends FormQuestionWidget
      */
     public function generate()
     {
-        $template = new \FrontendTemplate('survey_question_openended');
-        $template->ctrl_name = \StringUtil::specialchars($this->strName);
-        $template->ctrl_id = \StringUtil::specialchars($this->strId);
+        $template = new FrontendTemplate('survey_question_openended');
+        $template->ctrl_name = StringUtil::specialchars($this->strName);
+        $template->ctrl_id = StringUtil::specialchars($this->strId);
         $template->ctrl_class = (\strlen($this->strClass) ? ' '.$this->strClass : '');
         $template->multiLine = (0 == strcmp($this->questiontype, 'oe_multiline'));
         $template->singleLine = (0 == strcmp($this->questiontype, 'oe_singleline'));
@@ -145,16 +149,16 @@ class FormOpenEndedQuestion extends FormQuestionWidget
     protected function setData_oe_singleline($varValue)
     {
         if (\strlen($varValue['openended_width'])) {
-            $this->arrAttributes['size'] = \StringUtil::specialchars($varValue['openended_width']);
+            $this->arrAttributes['size'] = StringUtil::specialchars($varValue['openended_width']);
         }
         if (\strlen($varValue['openended_maxlen'])) {
-            $this->arrAttributes['maxlength'] = \StringUtil::specialchars($varValue['openended_maxlen']);
+            $this->arrAttributes['maxlength'] = StringUtil::specialchars($varValue['openended_maxlen']);
         }
         if (\strlen($varValue['openended_textinside'])) {
-            $this->arrAttributes['value'] = \StringUtil::specialchars($varValue['openended_textinside']);
+            $this->arrAttributes['value'] = StringUtil::specialchars($varValue['openended_textinside']);
         }
         if (\strlen($this->varValue)) {
-            $this->arrAttributes['value'] = \StringUtil::specialchars($this->varValue);
+            $this->arrAttributes['value'] = StringUtil::specialchars($this->varValue);
         }
     }
 
@@ -181,10 +185,10 @@ class FormOpenEndedQuestion extends FormQuestionWidget
     protected function setData_oe_multiline($varValue)
     {
         if (\strlen($varValue['openended_rows'])) {
-            $this->arrAttributes['rows'] = \StringUtil::specialchars($varValue['openended_rows']);
+            $this->arrAttributes['rows'] = StringUtil::specialchars($varValue['openended_rows']);
         }
         if (\strlen($varValue['openended_cols'])) {
-            $this->arrAttributes['cols'] = \StringUtil::specialchars($varValue['openended_cols']);
+            $this->arrAttributes['cols'] = StringUtil::specialchars($varValue['openended_cols']);
         }
         if (!\strlen($this->varValue)) {
             if (\strlen($varValue['openended_textinside'])) {

--- a/src/Resources/contao/forms/FormQuestionWidget.php
+++ b/src/Resources/contao/forms/FormQuestionWidget.php
@@ -10,6 +10,8 @@
 
 namespace Hschottm\SurveyBundle;
 
+use Contao\Widget;
+
 /**
  * Class FormQuestionWidget.
  *
@@ -18,7 +20,7 @@ namespace Hschottm\SurveyBundle;
  * @copyright  Helmut Schottmüller 2009-2010
  * @author     Helmut Schottmüller <contao@aurealis.de>
  */
-class FormQuestionWidget extends \Widget
+class FormQuestionWidget extends Widget
 {
     /**
      * Submit user input.

--- a/src/Resources/contao/models/SurveyModel.php
+++ b/src/Resources/contao/models/SurveyModel.php
@@ -10,7 +10,9 @@
 
 namespace Hschottm\SurveyBundle;
 
-class SurveyModel extends \Model
+use Contao\Model;
+
+class SurveyModel extends Model
 {
     /**
      * Table name.

--- a/src/Resources/contao/models/SurveyQuestionModel.php
+++ b/src/Resources/contao/models/SurveyQuestionModel.php
@@ -11,6 +11,7 @@
 namespace Hschottm\SurveyBundle;
 
 use Contao\Model;
+use Contao\System;
 
 class SurveyQuestionModel extends Model
 {

--- a/src/Resources/contao/models/SurveyResultModel.php
+++ b/src/Resources/contao/models/SurveyResultModel.php
@@ -10,6 +10,7 @@
 
 namespace Hschottm\SurveyBundle;
 
+use Contao\Database;
 use Contao\Model;
 
 class SurveyResultModel extends Model
@@ -36,7 +37,7 @@ class SurveyResultModel extends Model
 
         $t = static::$strTable;
 
-        return static::findBy(["$t.id IN(".implode(',', array_map('intval', $arrIds)).')'], null, ['order' => \Database::getInstance()->findInSet("$t.id", $arrIds)]);
+        return static::findBy(["$t.id IN(".implode(',', array_map('intval', $arrIds)).')'], null, ['order' => Database::getInstance()->findInSet("$t.id", $arrIds)]);
     }
 }
 

--- a/src/Resources/contao/templates/survey/survey_question_constantsum.html5
+++ b/src/Resources/contao/templates/survey/survey_question_constantsum.html5
@@ -3,11 +3,11 @@
 <?php foreach ($this->choices as $choice): ?>
 	<tr class="<?php echo ($counter %2 == 0) ? 'even' : 'odd'; ?>">
 <?php if ($this->blnInputFirst): ?>
-		<td class="col1"><input type="text" name="<?php echo $this->name; ?>[<?php echo $counter; ?>]" id="ctrl_<?php echo $this->ctrl_id; ?>_<?php echo $counter; ?>" class="text<?php echo $this->ctrl_class; ?>" <?php if (strlen($this->values[$counter])): ?>value="<?php echo \StringUtil::specialchars($this->values[$counter]); ?>" <?php endif; ?>/></td>
+		<td class="col1"><input type="text" name="<?php echo $this->name; ?>[<?php echo $counter; ?>]" id="ctrl_<?php echo $this->ctrl_id; ?>_<?php echo $counter; ?>" class="text<?php echo $this->ctrl_class; ?>" <?php if (strlen($this->values[$counter])): ?>value="<?php echo Contao\StringUtil::specialchars($this->values[$counter]); ?>" <?php endif; ?>/></td>
 		<td class="col0"><label for="ctrl_<?php echo $this->ctrl_id; ?>_<?php echo $counter; ?>"><?php echo $choice; ?></label></td>
 <?php else: ?>
 		<td class="col0"><label for="ctrl_<?php echo $this->ctrl_id; ?>_<?php echo $counter; ?>"><?php echo $choice; ?></label></td>
-		<td class="col1"><input type="text" name="<?php echo $this->name; ?>[<?php echo $counter; ?>]" id="ctrl_<?php echo $this->ctrl_id; ?>_<?php echo $counter; ?>" class="text<?php echo $this->ctrl_class; ?>" <?php if (strlen($this->values[$counter])): ?>value="<?php echo \StringUtil::specialchars($this->values[$counter]); ?>" <?php endif; ?>/></td>
+		<td class="col1"><input type="text" name="<?php echo $this->name; ?>[<?php echo $counter; ?>]" id="ctrl_<?php echo $this->ctrl_id; ?>_<?php echo $counter; ?>" class="text<?php echo $this->ctrl_class; ?>" <?php if (strlen($this->values[$counter])): ?>value="<?php echo Contao\StringUtil::specialchars($this->values[$counter]); ?>" <?php endif; ?>/></td>
 <?php endif; ?>
 	</tr>
 <?php $counter++; ?>

--- a/src/Resources/contao/templates/survey/survey_question_multiplechoice.html5
+++ b/src/Resources/contao/templates/survey/survey_question_multiplechoice.html5
@@ -4,11 +4,11 @@
 	<tr>
 <?php $counter = 1; ?>
 <?php foreach ($this->choices as $choice): ?>
-		<td><label for="ctrl_<?php echo $this->ctrl_id; ?>_<?php echo $counter; ?>"><?php echo \StringUtil::specialchars($choice); ?></label></td>
+		<td><label for="ctrl_<?php echo $this->ctrl_id; ?>_<?php echo $counter; ?>"><?php echo Contao\StringUtil::specialchars($choice); ?></label></td>
 <?php $counter++; ?>
 <?php endforeach; ?>
 <?php if ($this->blnOther): ?>
-		<td><label for="ctrl_<?php echo $this->ctrl_id; ?>_<?php echo $counter; ?>"><?php echo $this->otherTitle; ?></label> <input type="text" name="other_<?php echo $this->ctrl_name; ?>" class="text<?php echo $this->ctrl_class; ?>" <?php if (strlen($this->values["other"])): ?>value="<?php echo \StringUtil::specialchars($this->values['other']); ?>" <?php endif; ?>/></td>
+		<td><label for="ctrl_<?php echo $this->ctrl_id; ?>_<?php echo $counter; ?>"><?php echo $this->otherTitle; ?></label> <input type="text" name="other_<?php echo $this->ctrl_name; ?>" class="text<?php echo $this->ctrl_class; ?>" <?php if (strlen($this->values["other"])): ?>value="<?php echo Contao\StringUtil::specialchars($this->values['other']); ?>" <?php endif; ?>/></td>
 <?php endif; ?>
 <?php $counter = 1; ?>
 	</tr>
@@ -26,7 +26,7 @@
 <table>
 	<tr>
 <?php for ($counter = 1; $counter <= 2; $counter++): ?>
-		<td><label for="ctrl_<?php echo $this->ctrl_id; ?>_<?php echo $counter; ?>"><?php echo \StringUtil::specialchars(($counter == 1) ? $this->lngYes : $this->lngNo); ?></label></td>
+		<td><label for="ctrl_<?php echo $this->ctrl_id; ?>_<?php echo $counter; ?>"><?php echo Contao\StringUtil::specialchars(($counter == 1) ? $this->lngYes : $this->lngNo); ?></label></td>
 <?php endfor; ?>
 	</tr>
 	<tr>
@@ -41,11 +41,11 @@
 <?php $counter = 1; ?>
 <?php $values = is_array($this->values["value"]) ? $this->values["value"] : array(); ?>
 <?php foreach ($this->choices as $choice): ?>
-		<td><label for="ctrl_<?php echo $this->ctrl_id; ?>_<?php echo $counter; ?>"><?php echo \StringUtil::specialchars($choice); ?></label></td>
+		<td><label for="ctrl_<?php echo $this->ctrl_id; ?>_<?php echo $counter; ?>"><?php echo Contao\StringUtil::specialchars($choice); ?></label></td>
 <?php $counter++; ?>
 <?php endforeach; ?>
 <?php if ($this->blnOther): ?>
-		<td><label for="ctrl_<?php echo $this->ctrl_id; ?>_<?php echo $counter; ?>"><?php echo $this->otherTitle; ?></label> <input type="text" name="other_<?php echo $this->ctrl_name; ?>" class="text<?php echo $this->ctrl_class; ?>" <?php if (strlen($this->values["other"])): ?>value="<?php echo \StringUtil::specialchars($this->values['other']); ?>" <?php endif; ?>/></td>
+		<td><label for="ctrl_<?php echo $this->ctrl_id; ?>_<?php echo $counter; ?>"><?php echo $this->otherTitle; ?></label> <input type="text" name="other_<?php echo $this->ctrl_name; ?>" class="text<?php echo $this->ctrl_class; ?>" <?php if (strlen($this->values["other"])): ?>value="<?php echo Contao\StringUtil::specialchars($this->values['other']); ?>" <?php endif; ?>/></td>
 <?php endif; ?>
 <?php $counter = 1; ?>
 	</tr>
@@ -64,25 +64,25 @@
 <?php if ($this->singleResponse): ?>
 <?php $counter = 1; ?>
 <?php foreach ($this->choices as $choice): ?>
-<div><input type="radio" name="<?php echo $this->ctrl_name; ?>" id="ctrl_<?php echo $this->ctrl_id; ?>_<?php echo $counter; ?>" class="radio<?php echo $this->ctrl_class; ?>" value="<?php echo $counter; ?>"<?php if ($this->values['value'] == $counter): ?> checked="checked"<?php endif; ?> /> <label for="ctrl_<?php echo $this->ctrl_id; ?>_<?php echo $counter; ?>"><?php echo \StringUtil::specialchars($choice); ?></label></div>
+<div><input type="radio" name="<?php echo $this->ctrl_name; ?>" id="ctrl_<?php echo $this->ctrl_id; ?>_<?php echo $counter; ?>" class="radio<?php echo $this->ctrl_class; ?>" value="<?php echo $counter; ?>"<?php if ($this->values['value'] == $counter): ?> checked="checked"<?php endif; ?> /> <label for="ctrl_<?php echo $this->ctrl_id; ?>_<?php echo $counter; ?>"><?php echo Contao\StringUtil::specialchars($choice); ?></label></div>
 <?php $counter++; ?>
 <?php endforeach; ?>
 <?php if ($this->blnOther): ?>
-<div><input type="radio" name="<?php echo $this->ctrl_name; ?>" id="ctrl_<?php echo $this->ctrl_id; ?>_<?php echo $counter; ?>" class="radio<?php echo $this->ctrl_class; ?>" value="<?php echo $counter; ?>"<?php if ($this->values['value'] == $counter): ?> checked="checked"<?php endif; ?> /> <label for="ctrl_<?php echo $this->ctrl_id; ?>_<?php echo $counter; ?>"><?php echo $this->otherTitle; ?></label> <input type="text" name="other_<?php echo $this->ctrl_name; ?>" class="text<?php echo $this->ctrl_class; ?>" <?php if (strlen($this->values["other"])): ?>value="<?php echo \StringUtil::specialchars($this->values['other']); ?>" <?php endif; ?>/></div>
+<div><input type="radio" name="<?php echo $this->ctrl_name; ?>" id="ctrl_<?php echo $this->ctrl_id; ?>_<?php echo $counter; ?>" class="radio<?php echo $this->ctrl_class; ?>" value="<?php echo $counter; ?>"<?php if ($this->values['value'] == $counter): ?> checked="checked"<?php endif; ?> /> <label for="ctrl_<?php echo $this->ctrl_id; ?>_<?php echo $counter; ?>"><?php echo $this->otherTitle; ?></label> <input type="text" name="other_<?php echo $this->ctrl_name; ?>" class="text<?php echo $this->ctrl_class; ?>" <?php if (strlen($this->values["other"])): ?>value="<?php echo Contao\StringUtil::specialchars($this->values['other']); ?>" <?php endif; ?>/></div>
 <?php endif; ?>
 <?php elseif ($this->dichotomous): ?>
 <?php for ($counter = 1; $counter <= 2; $counter++): ?>
-<div><input type="radio" name="<?php echo $this->ctrl_name; ?>" id="ctrl_<?php echo $this->ctrl_id; ?>_<?php echo $counter; ?>" class="radio<?php echo $this->ctrl_class; ?>" value="<?php echo $counter; ?>"<?php if ($this->values['value'] == $counter): ?> checked="checked"<?php endif; ?> /> <label for="ctrl_<?php echo $this->ctrl_id; ?>_<?php echo $counter; ?>"><?php echo \StringUtil::specialchars(($counter == 1) ? $this->lngYes : $this->lngNo); ?></label></div>
+<div><input type="radio" name="<?php echo $this->ctrl_name; ?>" id="ctrl_<?php echo $this->ctrl_id; ?>_<?php echo $counter; ?>" class="radio<?php echo $this->ctrl_class; ?>" value="<?php echo $counter; ?>"<?php if ($this->values['value'] == $counter): ?> checked="checked"<?php endif; ?> /> <label for="ctrl_<?php echo $this->ctrl_id; ?>_<?php echo $counter; ?>"><?php echo Contao\StringUtil::specialchars(($counter == 1) ? $this->lngYes : $this->lngNo); ?></label></div>
 <?php endfor; ?>
 <?php elseif ($this->multipleResponse): ?>
 <?php $values = is_array($this->values["value"]) ? $this->values["value"] : array(); ?>
 <?php $counter = 1; ?>
 <?php foreach ($this->choices as $choice): ?>
-<div><input type="checkbox" name="<?php echo $this->ctrl_name; ?>[<?php echo $counter; ?>]" id="ctrl_<?php echo $this->ctrl_id; ?>_<?php echo $counter; ?>" class="checkbox<?php echo $this->ctrl_class; ?>" value="<?php echo $counter; ?>"<?php if (in_array($counter, $values)): ?> checked="checked"<?php endif; ?> /> <label for="ctrl_<?php echo $this->ctrl_id; ?>_<?php echo $counter; ?>"><?php echo \StringUtil::specialchars($choice); ?></label></div>
+<div><input type="checkbox" name="<?php echo $this->ctrl_name; ?>[<?php echo $counter; ?>]" id="ctrl_<?php echo $this->ctrl_id; ?>_<?php echo $counter; ?>" class="checkbox<?php echo $this->ctrl_class; ?>" value="<?php echo $counter; ?>"<?php if (in_array($counter, $values)): ?> checked="checked"<?php endif; ?> /> <label for="ctrl_<?php echo $this->ctrl_id; ?>_<?php echo $counter; ?>"><?php echo Contao\StringUtil::specialchars($choice); ?></label></div>
 <?php $counter++; ?>
 <?php endforeach; ?>
 <?php if ($this->blnOther): ?>
-<div><input type="checkbox" name="<?php echo $this->ctrl_name; ?>[<?php echo $counter; ?>]" id="ctrl_<?php echo $this->ctrl_id; ?>_<?php echo $counter; ?>" class="checkbox<?php echo $this->ctrl_class; ?>" value="<?php echo $counter; ?>"<?php if (in_array($counter, $values)): ?> checked="checked"<?php endif; ?> /> <label for="ctrl_<?php echo $this->ctrl_id; ?>_<?php echo $counter; ?>"><?php echo $this->otherTitle; ?></label> <input type="text" name="other_<?php echo $this->ctrl_name; ?>" class="text<?php echo $this->ctrl_class; ?>" <?php if (strlen($this->values["other"])): ?>value="<?php echo \StringUtil::specialchars($this->values['other']); ?>" <?php endif; ?>/></div>
+<div><input type="checkbox" name="<?php echo $this->ctrl_name; ?>[<?php echo $counter; ?>]" id="ctrl_<?php echo $this->ctrl_id; ?>_<?php echo $counter; ?>" class="checkbox<?php echo $this->ctrl_class; ?>" value="<?php echo $counter; ?>"<?php if (in_array($counter, $values)): ?> checked="checked"<?php endif; ?> /> <label for="ctrl_<?php echo $this->ctrl_id; ?>_<?php echo $counter; ?>"><?php echo $this->otherTitle; ?></label> <input type="text" name="other_<?php echo $this->ctrl_name; ?>" class="text<?php echo $this->ctrl_class; ?>" <?php if (strlen($this->values["other"])): ?>value="<?php echo Contao\StringUtil::specialchars($this->values['other']); ?>" <?php endif; ?>/></div>
 <?php endif; ?>
 <?php endif; ?>
 <?php elseif ($this->styleSelect): ?>
@@ -92,7 +92,7 @@
 		<option value="0"></option>
 <?php $counter = 1; ?>
 <?php foreach ($this->choices as $choice): ?>
-		<option value="<?php echo $counter; ?>"<?php if ($this->values['value'] == $counter): ?> selected="selected"<?php endif; ?>><?php echo \StringUtil::specialchars($choice); ?></option>
+		<option value="<?php echo $counter; ?>"<?php if ($this->values['value'] == $counter): ?> selected="selected"<?php endif; ?>><?php echo Contao\StringUtil::specialchars($choice); ?></option>
 <?php $counter++; ?>
 <?php endforeach; ?>
 	</select>
@@ -103,7 +103,7 @@
 		<option value="0"></option>
 <?php $counter = 1; ?>
 <?php for ($counter = 1; $counter <= 2; $counter++): ?>
-		<option value="<?php echo $counter; ?>"<?php if ($this->values['value'] == $counter): ?> selected="selected"<?php endif; ?>><?php echo \StringUtil::specialchars(($counter == 1) ? $this->lngYes : $this->lngNo); ?></option>
+		<option value="<?php echo $counter; ?>"<?php if ($this->values['value'] == $counter): ?> selected="selected"<?php endif; ?>><?php echo Contao\StringUtil::specialchars(($counter == 1) ? $this->lngYes : $this->lngNo); ?></option>
 <?php endfor; ?>
 	</select>
 </div>

--- a/src/Resources/contao/widgets/ConditionWizard.php
+++ b/src/Resources/contao/widgets/ConditionWizard.php
@@ -9,6 +9,9 @@
 
  namespace Hschottm\SurveyBundle;
 
+use Contao\BackendTemplate;
+use Contao\Widget;
+
 /**
  * Class ConditionWizard
  *
@@ -16,7 +19,7 @@
  *
  * @property integer $maxlength
  */
-class ConditionWizard extends \Widget
+class ConditionWizard extends Widget
 {
 	/**
 	 * Submit user input
@@ -68,7 +71,7 @@ class ConditionWizard extends \Widget
 	 */
 	public function generate()
 	{
-    $tpl = new \BackendTemplate('be_condition_wizard');
+    $tpl = new BackendTemplate('be_condition_wizard');
     return $tpl->parse();
   }
 }


### PR DESCRIPTION
If you try to extend/replace the `ContentSurvey` content element as a proper fragment (so that you can use DI etc.) using [this method](https://docs.contao.org/dev/guides/fragment-controllers/#extending-an-existing-class) an error will occur saying that the class `ContentElement` could not be found. This is because the `ContentSurvey` content elements extends from `\ContentElement`, which is a Contao 2 remnant. Contao classes from the global namespace should not be used in general anymore.

This PR fixes the issue by extending from `\Contao\ContentElement` instead. However I decided to go ahead and also fix the usage of the global namespace everywhere else as well. I did notice though that this extension still has a (missing) dependency on https://github.com/hschottm/xls_export (which is not supported in newer Contao versions anymore). So this PR doesn't actually fix all issues.