### PR TITLE
Fixed for issues with php 8 and multiple choices

### DIFF
--- a/src/DataContainer/SurveyContainer.php
+++ b/src/DataContainer/SurveyContainer.php
@@ -23,9 +23,9 @@ class SurveyContainer
             return;
         }
 
-        $found = ($id = $request->query->get('id', false)) ? (is_numeric($id) ? (SurveyResultModel::findByPid((int)$id)) : null) : null;
+        $resultData = ($id = $request->query->get('id', false)) ? (is_numeric($id) ? (SurveyResultModel::findByPid((int)$id)) : null) : null;
 
-        if ($found) {
+        if ($resultData) {
             $GLOBALS['TL_DCA']['tl_survey']['fields']['access']['eval']['disabled'] = 'disabled';
         }
 

--- a/src/DataContainer/SurveyContainer.php
+++ b/src/DataContainer/SurveyContainer.php
@@ -1,5 +1,19 @@
 <?php
 
+declare(strict_types=1);
+
+/*
+ * @copyright  Helmut Schottmüller 2005-2018 <http://github.com/hschottm>
+ * @author     Helmut Schottmüller (hschottm)
+ * @package    contao-survey
+ * @license    LGPL-3.0+, CC-BY-NC-3.0
+ * @see	       https://github.com/hschottm/survey_ce
+ *
+ * forked by pdir
+ * @author     Mathias Arzberger <develop@pdir.de>
+ * @link       https://github.com/pdir/contao-survey
+ */
+
 namespace Hschottm\SurveyBundle\DataContainer;
 
 use Contao\DataContainer;
@@ -23,11 +37,10 @@ class SurveyContainer
             return;
         }
 
-        $resultData = ($id = $request->query->get('id', false)) ? (is_numeric($id) ? (SurveyResultModel::findByPid((int)$id)) : null) : null;
+        $resultData = ($id = $request->query->get('id', false)) ? (is_numeric($id) ? SurveyResultModel::findByPid((int) $id) : null) : null;
 
         if ($resultData) {
             $GLOBALS['TL_DCA']['tl_survey']['fields']['access']['eval']['disabled'] = 'disabled';
         }
-
     }
 }

--- a/src/DataContainer/SurveyContainer.php
+++ b/src/DataContainer/SurveyContainer.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Hschottm\SurveyBundle\DataContainer;
+
+use Contao\DataContainer;
+use Hschottm\SurveyBundle\SurveyResultModel;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+class SurveyContainer
+{
+    private RequestStack $requestStack;
+
+    public function __construct(RequestStack $requestStack)
+    {
+        $this->requestStack = $requestStack;
+    }
+
+    public function onLoadCallback(DataContainer $dc = null): void
+    {
+        $request = $this->requestStack->getCurrentRequest();
+
+        if (null === $dc || !$dc->id || !$request || 'edit' !== $request->query->get('act')) {
+            return;
+        }
+
+        $found = ($id = $request->query->get('id', false)) ? (is_numeric($id) ? (SurveyResultModel::findByPid((int)$id)) : null) : null;
+
+        if ($found) {
+            $GLOBALS['TL_DCA']['tl_survey']['fields']['access']['eval']['disabled'] = 'disabled';
+        }
+
+    }
+}

--- a/src/DataContainer/SurveyPageContainer.php
+++ b/src/DataContainer/SurveyPageContainer.php
@@ -163,7 +163,7 @@ class SurveyPageContainer
     protected function hasData(int $id): bool
     {
         if (null === $this->hasData) {
-            $this->hasData = !null === SurveyResultModel::findByPid($id);
+            $this->hasData = null !== SurveyResultModel::findByPid($id);
         }
 
         return $this->hasData;

--- a/src/DataContainer/SurveyPageContainer.php
+++ b/src/DataContainer/SurveyPageContainer.php
@@ -59,7 +59,7 @@ class SurveyPageContainer
             return;
         }
 
-        $resultData = ($id = $request->query->get('id', false)) ? (is_numeric($id) ? (SurveyResultModel::findByPid((int)$id)) : null) : null;
+        $resultData = ($id = $request->query->get('id', false)) ? (is_numeric($id) ? SurveyResultModel::findByPid((int) $id) : null) : null;
 
         if ($resultData) {
             $dca = &$GLOBALS['TL_DCA']['tl_survey_page'];
@@ -163,7 +163,7 @@ class SurveyPageContainer
     protected function hasData(int $id): bool
     {
         if (null === $this->hasData) {
-            $this->hasData = !(null === SurveyResultModel::findByPid($id));
+            $this->hasData = !null === SurveyResultModel::findByPid($id);
         }
 
         return $this->hasData;
@@ -171,7 +171,6 @@ class SurveyPageContainer
 
     /**
      * @param DataContainer|null $dc
-     * @return void
      */
     private function adjustResultPageDca(DataContainer $dc, Request $request): void
     {
@@ -193,6 +192,7 @@ class SurveyPageContainer
 
         PaletteManipulator::create()
             ->addField('hideBackButton', 'config_legend', PaletteManipulator::POSITION_APPEND)
-            ->applyToPalette(static::PAGETYPE_RESULT, static::TABLE);
+            ->applyToPalette(static::PAGETYPE_RESULT, static::TABLE)
+        ;
     }
 }

--- a/src/DataContainer/SurveyPageContainer.php
+++ b/src/DataContainer/SurveyPageContainer.php
@@ -28,6 +28,7 @@ use Contao\StringUtil;
 use Hschottm\SurveyBundle\SurveyModel;
 use Hschottm\SurveyBundle\SurveyPageModel;
 use Hschottm\SurveyBundle\SurveyResultModel;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Security\Core\Security;
 
@@ -52,26 +53,21 @@ class SurveyPageContainer
      */
     public function onLoadCallback(DataContainer $dc = null): void
     {
-        if (null === $dc || !$dc->id || 'edit' !== $this->requestStack->getCurrentRequest()->query->get('act')) {
+        $request = $this->requestStack->getCurrentRequest();
+
+        if (!$dc || !$request) {
             return;
         }
 
-        $surveyPageModel = SurveyPageModel::findByPk($dc->id);
+        $resultData = ($id = $request->query->get('id', false)) ? (is_numeric($id) ? (SurveyResultModel::findByPid((int)$id)) : null) : null;
 
-        if (!$surveyPageModel || static::PAGETYPE_RESULT !== $surveyPageModel->type) {
-            return;
+        if ($resultData) {
+            $dca = &$GLOBALS['TL_DCA']['tl_survey_page'];
+            $dca['config']['notEditable'] = true;
+            $dca['config']['closed'] = true;
         }
 
-        $surveyModel = SurveyModel::findById($surveyPageModel->pid);
-
-        if (!$surveyModel || !$surveyModel->allowback) {
-            return;
-        }
-
-        PaletteManipulator::create()
-            ->addField('hideBackButton', 'config_legend', PaletteManipulator::POSITION_APPEND)
-            ->applyToPalette(static::PAGETYPE_RESULT, static::TABLE)
-        ;
+        $this->adjustResultPageDca($dc, $request);
     }
 
     /**
@@ -167,9 +163,36 @@ class SurveyPageContainer
     protected function hasData(int $id): bool
     {
         if (null === $this->hasData) {
-            $this->hasData = !null === SurveyResultModel::findByPid($id);
+            $this->hasData = !(null === SurveyResultModel::findByPid($id));
         }
 
         return $this->hasData;
+    }
+
+    /**
+     * @param DataContainer|null $dc
+     * @return void
+     */
+    private function adjustResultPageDca(DataContainer $dc, Request $request): void
+    {
+        if (!$dc->id || 'edit' !== $request->query->get('act')) {
+            return;
+        }
+
+        $surveyPageModel = SurveyPageModel::findByPk($dc->id);
+
+        if (!$surveyPageModel || static::PAGETYPE_RESULT !== $surveyPageModel->type) {
+            return;
+        }
+
+        $surveyModel = SurveyModel::findById($surveyPageModel->pid);
+
+        if (!$surveyModel || !$surveyModel->allowback) {
+            return;
+        }
+
+        PaletteManipulator::create()
+            ->addField('hideBackButton', 'config_legend', PaletteManipulator::POSITION_APPEND)
+            ->applyToPalette(static::PAGETYPE_RESULT, static::TABLE);
     }
 }

--- a/src/EventListener/CategoriesListener.php
+++ b/src/EventListener/CategoriesListener.php
@@ -63,7 +63,7 @@ class CategoriesListener
             $choicesField = &$GLOBALS['TL_DCA'][SurveyQuestionModel::getTable()]['fields']['choices'];
             $choicesField['palette'][] = 'category';
             $choicesField['fields']['choice']['eval']['tl_class'] =
-                trim(('' === $choicesField['fields']['choice']['eval']['tl_class']).' w50');
+                trim(($choicesField['fields']['choice']['eval']['tl_class'] ?? '').' w50');
             $choicesField['fields']['category'] = [
                 'inputType' => 'select',
                 'options_callback' => [self::class, 'surveyChoicesCategoryOptionsCallback'],

--- a/src/Resources/contao/classes/SurveyQuestionMultiplechoice.php
+++ b/src/Resources/contao/classes/SurveyQuestionMultiplechoice.php
@@ -81,10 +81,7 @@ class SurveyQuestionMultiplechoice extends SurveyQuestion
 
                     if (isset($choice['category'])) {
                         $result['categories'][$choice['category']] =
-                            (
-                                ($result['categories'][$choice['category']] ?? 0) +
-                                ($this->statistics['cumulated'][$id] ?? 0)
-                            );
+                            (($result['categories'][$choice['category']] ?? 0) + ($this->statistics['cumulated'][$id] ?? 0));
                     }
 
                     ++$counter;

--- a/src/Resources/contao/classes/SurveyQuestionMultiplechoice.php
+++ b/src/Resources/contao/classes/SurveyQuestionMultiplechoice.php
@@ -72,16 +72,19 @@ class SurveyQuestionMultiplechoice extends SurveyQuestion
                 $counter = 1;
 
                 foreach ($result['choices'] as $id => $choice) {
-                    $choice = $choice['choice'];
                     $result['choices'][$id] = $choice;
 
                     $result['answers'][$counter] = [
-                        'choices' => $choice,
+                        'choices' => $choice['choice'],
                         'selections' => ($this->statistics['cumulated'][$id] ?? 0),
                     ];
 
                     if (isset($choice['category'])) {
-                        $result['categories'][$choice['category']] = (($result['categories'][$choice['category']] ?? 0) + $this->statistics['cumulated'][$id] ?? 0);
+                        $result['categories'][$choice['category']] =
+                            (
+                                ($result['categories'][$choice['category']] ?? 0) +
+                                ($this->statistics['cumulated'][$id] ?? 0)
+                            );
                     }
 
                     ++$counter;
@@ -275,7 +278,7 @@ class SurveyQuestionMultiplechoice extends SurveyQuestion
                     }
                 }
 
-                if (\strlen($arrAnswer['other'])) {
+                if ($arrAnswer['other'] ?? false) {
                     $found = true;
                 }
 
@@ -305,12 +308,12 @@ class SurveyQuestionMultiplechoice extends SurveyQuestion
                     }
                 }
             } else {
-                if (\strlen($arrAnswer['value'])) {
-                    ++$cumulated[$arrAnswer['value']];
+                if ($arrAnswer['value'] ?? false) {
+                    $cumulated[$arrAnswer['value']] = ($cumulated[$arrAnswer['value']] ?? 0) + 1;
                 }
             }
 
-            if (\strlen($arrAnswer['other'])) {
+            if ($arrAnswer['other'] ?? false) {
                 array_push($cumulated['other'], $arrAnswer['other']);
             }
         }

--- a/src/Resources/contao/classes/SurveyResultDetails.php
+++ b/src/Resources/contao/classes/SurveyResultDetails.php
@@ -51,7 +51,7 @@ class SurveyResultDetails extends Backend
             return '';
         }
         $return = '';
-        $qid = Input::get('id');
+        $qid = (int)Input::get('id');
         $qtype = $this->Database->prepare('SELECT questiontype, pid FROM tl_survey_question WHERE id = ?')
             ->execute($qid)
             ->fetchAssoc()
@@ -60,16 +60,15 @@ class SurveyResultDetails extends Backend
             ->execute($qtype['pid'])
             ->fetchAssoc()
         ;
-        $class = 'Hschottm\\SurveyBundle\\SurveyQuestion'.ucfirst($qtype['questiontype']);
         $this->loadLanguageFile('tl_survey_result');
         $this->loadLanguageFile('tl_survey_question');
         $this->Template = new BackendTemplate('be_question_result_details');
         $this->Template->back = $GLOBALS['TL_LANG']['MSC']['goBack'];
         $this->Template->hrefBack = Backend::addToUrl('key=cumulated&amp;id='.$parent['pid'], true, ['key', 'id']);
 
-        if ($this->classFileExists($class)) {
-            $this->import($class);
-            $question = new $class($qid);
+        $question = SurveyQuestion::createInstance($qid, $qtype['questiontype']);
+
+        if ($question) {
             $this->Template->summary = $GLOBALS['TL_LANG']['tl_survey_result']['detailsSummary'];
             $this->Template->heading = sprintf($GLOBALS['TL_LANG']['tl_survey_result']['detailsHeading'], $qid);
             $data = [];

--- a/src/Resources/contao/dca/tl_survey.php
+++ b/src/Resources/contao/dca/tl_survey.php
@@ -19,10 +19,6 @@ use Contao\BackendUser;
 use Contao\Database;
 use Contao\Input;
 use Doctrine\DBAL\Platforms\MySqlPlatform;
-use Hschottm\SurveyBundle\SurveyResultModel;
-
-$found = strlen(Input::get('id')) ? SurveyResultModel::findByPid(Input::get('id')) : null;
- $hasData = null !== $found && 0 < $found->count() ? true : false;
 
 /*
  * Table tl_survey
@@ -518,10 +514,6 @@ $GLOBALS['TL_DCA']['tl_survey']['fields']['confirmationMailAlternateAttachments'
     'eval' => ['fieldType' => 'checkbox', 'files' => true, 'filesOnly' => true, 'multiple' => true, 'mandatory' => true],
     'sql' => 'blob NULL',
 ];
-
-if ($hasData) {
-    $GLOBALS['TL_DCA']['tl_survey']['fields']['access']['eval']['disabled'] = 'disabled';
-}
 
 /**
  * Class tl_survey.

--- a/src/Resources/contao/dca/tl_survey_page.php
+++ b/src/Resources/contao/dca/tl_survey_page.php
@@ -15,198 +15,165 @@ declare(strict_types=1);
  */
 
 use Contao\Backend;
+use Contao\DC_Table;
 use Contao\Input;
 use Contao\StringUtil;
 use Hschottm\SurveyBundle\SurveyResultModel;
 
- $found = strlen(Input::get('id')) ? SurveyResultModel::findByPid(Input::get('id')) : null;
- $hasData = null !== $found && 0 < $found->count() ? true : false;
-
-if ($hasData) {
-    /*
-     * Table tl_survey_question
-     */
-    $GLOBALS['TL_DCA']['tl_survey_page'] = [
-        // Config
-        'config' => [
-            'dataContainer' => 'Table',
-            'ptable' => 'tl_survey',
-            'ctable' => ['tl_survey_question'],
-            'notEditable' => true,
-            'closed' => true,
-            'sql' => [
-                'keys' => [
-                    'id' => 'primary',
-                    'pid' => 'index',
-                ],
+$GLOBALS['TL_DCA']['tl_survey_page'] = [
+    // Config
+    'config'      => [
+        'dataContainer'    => DC_Table::class,
+        'ptable'           => 'tl_survey',
+        'ctable'           => ['tl_survey_question'],
+        'switchToEdit'     => true,
+        'enableVersioning' => true,
+        'sql'              => [
+            'keys' => [
+                'id'  => 'primary',
+                'pid' => 'index',
             ],
         ],
-    ];
-} else {
-    /*
-     * Table tl_survey_question
-     */
-    $GLOBALS['TL_DCA']['tl_survey_page'] = [
-        // Config
-        'config' => [
-            'dataContainer' => 'Table',
-            'ptable' => 'tl_survey',
-            'ctable' => ['tl_survey_question'],
-            'switchToEdit' => true,
-            'enableVersioning' => true,
-            'sql' => [
-                'keys' => [
-                    'id' => 'primary',
-                    'pid' => 'index',
-                ],
+    ],
+    'list'        => [
+        'sorting'    => [
+            'mode'                  => 4,
+            'filter'                => true,
+            'fields'                => ['sorting'],
+            'panelLayout'           => 'search,filter,limit',
+            'headerFields'          => ['title', 'tstamp', 'description'],
+            'child_record_callback' => ['\Hschottm\SurveyBundle\SurveyPagePreview', 'compilePreview'],
+        ],
+        'operations' => [
+            'edit'       => [
+                'label' => &$GLOBALS['TL_LANG']['tl_survey_page']['edit'],
+                'href'  => 'table=tl_survey_question',
+                'icon'  => 'edit.svg',
+            ],
+            'editheader' => [
+                'href' => 'act=edit',
+                'icon' => 'header.svg',
+            ],
+            'copy'       => [
+                'label'           => &$GLOBALS['TL_LANG']['tl_survey_page']['copy'],
+                'href'            => 'act=paste&mode=copy',
+                'icon'            => 'copy.svg',
+                'button_callback' => ['tl_survey_page', 'copyPage'],
+            ],
+            'cut'        => [
+                'label'           => &$GLOBALS['TL_LANG']['tl_survey_page']['cut'],
+                'href'            => 'act=paste&mode=cut',
+                'icon'            => 'cut.svg',
+                'attributes'      => 'onclick="Backend.getScrollOffset();"',
+                'button_callback' => ['tl_survey_page', 'cutPage'],
+            ],
+            'delete'     => [
+                'label'           => &$GLOBALS['TL_LANG']['tl_survey_page']['delete'],
+                'href'            => 'act=delete',
+                'icon'            => 'delete.svg',
+                'attributes'      => 'onclick="if (!confirm(\'' . ($GLOBALS['TL_LANG']['MSC']['deleteConfirm'] ?? null) . '\')) return false; Backend.getScrollOffset();"',
+                'button_callback' => ['tl_survey_page', 'deletePage'],
+            ],
+            'show'       => [
+                'label' => &$GLOBALS['TL_LANG']['tl_survey_page']['show'],
+                'href'  => 'act=show',
+                'icon'  => 'show.svg',
             ],
         ],
-    ];
-}
-
-// List
-$GLOBALS['TL_DCA']['tl_survey_page']['list'] = [
-    'sorting' => [
-        'mode' => 4,
-        'filter' => true,
-        'fields' => ['sorting'],
-        'panelLayout' => 'search,filter,limit',
-        'headerFields' => ['title', 'tstamp', 'description'],
-        'child_record_callback' => ['\Hschottm\SurveyBundle\SurveyPagePreview', 'compilePreview'],
     ],
-    'operations' => [
-        'edit' => [
-            'label' => &$GLOBALS['TL_LANG']['tl_survey_page']['edit'],
-            'href' => 'table=tl_survey_question',
-            'icon' => 'edit.svg',
+    'palettes'    => [
+        '__selector__' => ['type', 'useCustomNextButtonTitle'],
+        'default'      => '{type_legend},type;{title_legend},title,description;{intro_legend},introduction;{template_legend},page_template',
+        'result'       => '{type_legend},type;{title_legend},title,description;{intro_legend},introduction;{config_legend},useCustomNextButtonTitle;{template_legend},page_template',
+    ],
+    'subpalettes' => [
+        'useCustomNextButtonTitle' => 'customNextButtonTitle',
+    ],
+    'fields'      => [
+        'id'                       => [
+            'sql' => 'int(10) unsigned NOT NULL auto_increment',
         ],
-        'editheader' => [
-            'href' => 'act=edit',
-            'icon' => 'header.svg',
+        'tstamp'                   => [
+            'sql' => "int(10) unsigned NOT NULL default '0'",
         ],
-        'copy' => [
-            'label' => &$GLOBALS['TL_LANG']['tl_survey_page']['copy'],
-            'href' => 'act=paste&mode=copy',
-            'icon' => 'copy.svg',
-            'button_callback' => ['tl_survey_page', 'copyPage'],
+        'pid'                      => [
+            'sql' => "int(10) unsigned NOT NULL default '0'",
         ],
-        'cut' => [
-            'label' => &$GLOBALS['TL_LANG']['tl_survey_page']['cut'],
-            'href' => 'act=paste&mode=cut',
-            'icon' => 'cut.svg',
-            'attributes' => 'onclick="Backend.getScrollOffset();"',
-            'button_callback' => ['tl_survey_page', 'cutPage'],
+        'sorting'                  => [
+            'sql' => "int(10) unsigned NOT NULL default '0'",
         ],
-        'delete' => [
-            'label' => &$GLOBALS['TL_LANG']['tl_survey_page']['delete'],
-            'href' => 'act=delete',
-            'icon' => 'delete.svg',
-            'attributes' => 'onclick="if (!confirm(\''.($GLOBALS['TL_LANG']['MSC']['deleteConfirm'] ?? null).'\')) return false; Backend.getScrollOffset();"',
-            'button_callback' => ['tl_survey_page', 'deletePage'],
+        'type'                     => [
+            'exclude'   => true,
+            'filter'    => true,
+            'inputType' => 'select',
+            'options'   => ['default', 'result'],
+            'reference' => &$GLOBALS['TL_LANG']['tl_survey_page']['type'],
+            'eval'      => ['submitOnChange' => true, 'tl_class' => 'w50'],
+            'sql'       => ['name' => 'type', 'type' => 'string', 'length' => 8, 'default' => 'default'],
         ],
-        'show' => [
-            'label' => &$GLOBALS['TL_LANG']['tl_survey_page']['show'],
-            'href' => 'act=show',
-            'icon' => 'show.svg',
+        'title'                    => [
+            'label'     => &$GLOBALS['TL_LANG']['tl_survey_page']['title'],
+            'search'    => true,
+            'sorting'   => true,
+            'filter'    => true,
+            'flag'      => 1,
+            'inputType' => 'text',
+            'eval'      => ['mandatory' => true, 'maxlength' => 255, 'insertTag' => true],
+            'sql'       => "varchar(255) NOT NULL default ''",
         ],
-    ],
-];
-
-// Palettes
-$GLOBALS['TL_DCA']['tl_survey_page']['palettes'] = [
-    '__selector__' => ['type', 'useCustomNextButtonTitle'],
-    'default' => '{type_legend},type;{title_legend},title,description;{intro_legend},introduction;{template_legend},page_template',
-    'result' => '{type_legend},type;{title_legend},title,description;{intro_legend},introduction;{config_legend},useCustomNextButtonTitle;{template_legend},page_template',
-];
-$GLOBALS['TL_DCA']['tl_survey_page']['subpalettes'] = [
-    'useCustomNextButtonTitle' => 'customNextButtonTitle',
-];
-
-// Fields
-$GLOBALS['TL_DCA']['tl_survey_page']['fields'] = [
-    'id' => [
-        'sql' => 'int(10) unsigned NOT NULL auto_increment',
-    ],
-    'tstamp' => [
-        'sql' => "int(10) unsigned NOT NULL default '0'",
-    ],
-    'pid' => [
-        'sql' => "int(10) unsigned NOT NULL default '0'",
-    ],
-    'sorting' => [
-        'sql' => "int(10) unsigned NOT NULL default '0'",
-    ],
-    'type' => [
-        'exclude' => true,
-        'filter' => true,
-        'inputType' => 'select',
-        'options' => ['default', 'result'],
-        'reference' => &$GLOBALS['TL_LANG']['tl_survey_page']['type'],
-        'eval' => ['submitOnChange' => true, 'tl_class' => 'w50'],
-        'sql' => ['name' => 'type', 'type' => 'string', 'length' => 8, 'default' => 'default'],
-    ],
-    'title' => [
-        'label' => &$GLOBALS['TL_LANG']['tl_survey_page']['title'],
-        'search' => true,
-        'sorting' => true,
-        'filter' => true,
-        'flag' => 1,
-        'inputType' => 'text',
-        'eval' => ['mandatory' => true, 'maxlength' => 255, 'insertTag' => true],
-        'sql' => "varchar(255) NOT NULL default ''",
-    ],
-    'description' => [
-        'label' => &$GLOBALS['TL_LANG']['tl_survey_page']['description'],
-        'search' => true,
-        'inputType' => 'textarea',
-        'eval' => ['allowHtml' => true, 'style' => 'height:80px;'],
-        'sql' => 'text NULL',
-    ],
-    'language' => [
-        'sql' => "varchar(32) NOT NULL default ''",
-    ],
-    'introduction' => [
-        'label' => &$GLOBALS['TL_LANG']['tl_survey_page']['introduction'],
-        'default' => '',
-        'search' => true,
-        'inputType' => 'textarea',
-        'eval' => ['allowHtml' => true, 'style' => 'height:80px;', 'rte' => 'tinyMCE'],
-        'sql' => 'text NOT NULL',
-    ],
-    'conditions' => [
-        'label' => &$GLOBALS['TL_LANG']['tl_survey_page']['conditions'],
-        'default' => '',
-        'search' => true,
-        'inputType' => 'conditionwizard',
-        'eval' => [],
-        'sql' => "varchar(1) NOT NULL default ''",
-    ],
-    'page_template' => [
-        'label' => &$GLOBALS['TL_LANG']['tl_survey_page']['page_template'],
-        'default' => 'survey_questionblock',
-        'inputType' => 'select',
-        'eval' => ['tl_class' => 'w50'],
-        'sql' => "varchar(255) NOT NULL default 'survey_questionblock'",
-    ],
-    'pagetype' => [
-        'sql' => "varchar(30) NOT NULL default 'standard'",
-    ],
-    'useCustomNextButtonTitle' => [
-        'exclude' => true,
-        'inputType' => 'checkbox',
-        'eval' => ['tl_class' => 'w50', 'submitOnChange' => true],
-        'sql' => "char(1) NOT NULL default ''",
-    ],
-    'customNextButtonTitle' => [
-        'inputType' => 'text',
-        'eval' => ['mandatory' => true, 'maxlength' => 128],
-        'sql' => "varchar(128) NOT NULL default ''",
-    ],
-    'hideBackButton' => [
-        'exclude' => true,
-        'inputType' => 'checkbox',
-        'eval' => ['tl_class' => 'w50'],
-        'sql' => "char(1) NOT NULL default ''",
+        'description'              => [
+            'label'     => &$GLOBALS['TL_LANG']['tl_survey_page']['description'],
+            'search'    => true,
+            'inputType' => 'textarea',
+            'eval'      => ['allowHtml' => true, 'style' => 'height:80px;'],
+            'sql'       => 'text NULL',
+        ],
+        'language'                 => [
+            'sql' => "varchar(32) NOT NULL default ''",
+        ],
+        'introduction'             => [
+            'label'     => &$GLOBALS['TL_LANG']['tl_survey_page']['introduction'],
+            'default'   => '',
+            'search'    => true,
+            'inputType' => 'textarea',
+            'eval'      => ['allowHtml' => true, 'style' => 'height:80px;', 'rte' => 'tinyMCE'],
+            'sql'       => 'text NOT NULL',
+        ],
+        'conditions'               => [
+            'label'     => &$GLOBALS['TL_LANG']['tl_survey_page']['conditions'],
+            'default'   => '',
+            'search'    => true,
+            'inputType' => 'conditionwizard',
+            'eval'      => [],
+            'sql'       => "varchar(1) NOT NULL default ''",
+        ],
+        'page_template'            => [
+            'label'     => &$GLOBALS['TL_LANG']['tl_survey_page']['page_template'],
+            'default'   => 'survey_questionblock',
+            'inputType' => 'select',
+            'eval'      => ['tl_class' => 'w50'],
+            'sql'       => "varchar(255) NOT NULL default 'survey_questionblock'",
+        ],
+        'pagetype'                 => [
+            'sql' => "varchar(30) NOT NULL default 'standard'",
+        ],
+        'useCustomNextButtonTitle' => [
+            'exclude'   => true,
+            'inputType' => 'checkbox',
+            'eval'      => ['tl_class' => 'w50', 'submitOnChange' => true],
+            'sql'       => "char(1) NOT NULL default ''",
+        ],
+        'customNextButtonTitle'    => [
+            'inputType' => 'text',
+            'eval'      => ['mandatory' => true, 'maxlength' => 128],
+            'sql'       => "varchar(128) NOT NULL default ''",
+        ],
+        'hideBackButton'           => [
+            'exclude'   => true,
+            'inputType' => 'checkbox',
+            'eval'      => ['tl_class' => 'w50'],
+            'sql'       => "char(1) NOT NULL default ''",
+        ],
     ],
 ];
 
@@ -243,10 +210,10 @@ class tl_survey_page extends Backend
     public function copyPage($row, $href, $label, $title, $icon, $attributes)
     {
         if ($this->hasData()) {
-            return $this->generateImage(preg_replace('/\.svg$/i', '_.svg', $icon)).' ';
+            return $this->generateImage(preg_replace('/\.svg$/i', '_.svg', $icon)) . ' ';
         }
 
-        return '<a href="'.$this->addToUrl($href.'&id='.$row['id']).'" title="'.StringUtil::specialchars($title).'"'.$attributes.'>'.$this->generateImage($icon, $label).'</a> ';
+        return '<a href="' . $this->addToUrl($href . '&id=' . $row['id']) . '" title="' . StringUtil::specialchars($title) . '"' . $attributes . '>' . $this->generateImage($icon, $label) . '</a> ';
     }
 
     /**
@@ -270,10 +237,10 @@ class tl_survey_page extends Backend
     public function cutPage($row, $href, $label, $title, $icon, $attributes)
     {
         if ($this->hasData()) {
-            return $this->generateImage(preg_replace('/\.svg$/i', '_.svg', $icon)).' ';
+            return $this->generateImage(preg_replace('/\.svg$/i', '_.svg', $icon)) . ' ';
         }
 
-        return '<a href="'.$this->addToUrl($href.'&id='.$row['id']).'" title="'.StringUtil::specialchars($title).'"'.$attributes.'>'.$this->generateImage($icon, $label).'</a> ';
+        return '<a href="' . $this->addToUrl($href . '&id=' . $row['id']) . '" title="' . StringUtil::specialchars($title) . '"' . $attributes . '>' . $this->generateImage($icon, $label) . '</a> ';
     }
 
     /**
@@ -297,16 +264,16 @@ class tl_survey_page extends Backend
     public function deletePage($row, $href, $label, $title, $icon, $attributes)
     {
         if ($this->hasData()) {
-            return $this->generateImage(preg_replace('/\.svg$/i', '_.svg', $icon)).' ';
+            return $this->generateImage(preg_replace('/\.svg$/i', '_.svg', $icon)) . ' ';
         }
 
-        return '<a href="'.$this->addToUrl($href.'&id='.$row['id']).'" title="'.StringUtil::specialchars($title).'"'.$attributes.'>'.$this->generateImage($icon, $label).'</a> ';
+        return '<a href="' . $this->addToUrl($href . '&id=' . $row['id']) . '" title="' . StringUtil::specialchars($title) . '"' . $attributes . '>' . $this->generateImage($icon, $label) . '</a> ';
     }
 
     protected function hasData()
     {
         if (null === $this->hasData) {
-            $resultModel = SurveyResultModel::findBy(['pid=?'], [Input::get('id')]);
+            $resultModel   = SurveyResultModel::findBy(['pid=?'], [Input::get('id')]);
             $this->hasData = null !== $resultModel && $resultModel->count() > 0;
         }
 

--- a/src/Resources/contao/dca/tl_survey_page.php
+++ b/src/Resources/contao/dca/tl_survey_page.php
@@ -22,157 +22,157 @@ use Hschottm\SurveyBundle\SurveyResultModel;
 
 $GLOBALS['TL_DCA']['tl_survey_page'] = [
     // Config
-    'config'      => [
-        'dataContainer'    => DC_Table::class,
-        'ptable'           => 'tl_survey',
-        'ctable'           => ['tl_survey_question'],
-        'switchToEdit'     => true,
+    'config' => [
+        'dataContainer' => DC_Table::class,
+        'ptable' => 'tl_survey',
+        'ctable' => ['tl_survey_question'],
+        'switchToEdit' => true,
         'enableVersioning' => true,
-        'sql'              => [
+        'sql' => [
             'keys' => [
-                'id'  => 'primary',
+                'id' => 'primary',
                 'pid' => 'index',
             ],
         ],
     ],
-    'list'        => [
-        'sorting'    => [
-            'mode'                  => 4,
-            'filter'                => true,
-            'fields'                => ['sorting'],
-            'panelLayout'           => 'search,filter,limit',
-            'headerFields'          => ['title', 'tstamp', 'description'],
+    'list' => [
+        'sorting' => [
+            'mode' => 4,
+            'filter' => true,
+            'fields' => ['sorting'],
+            'panelLayout' => 'search,filter,limit',
+            'headerFields' => ['title', 'tstamp', 'description'],
             'child_record_callback' => ['\Hschottm\SurveyBundle\SurveyPagePreview', 'compilePreview'],
         ],
         'operations' => [
-            'edit'       => [
+            'edit' => [
                 'label' => &$GLOBALS['TL_LANG']['tl_survey_page']['edit'],
-                'href'  => 'table=tl_survey_question',
-                'icon'  => 'edit.svg',
+                'href' => 'table=tl_survey_question',
+                'icon' => 'edit.svg',
             ],
             'editheader' => [
                 'href' => 'act=edit',
                 'icon' => 'header.svg',
             ],
-            'copy'       => [
-                'label'           => &$GLOBALS['TL_LANG']['tl_survey_page']['copy'],
-                'href'            => 'act=paste&mode=copy',
-                'icon'            => 'copy.svg',
+            'copy' => [
+                'label' => &$GLOBALS['TL_LANG']['tl_survey_page']['copy'],
+                'href' => 'act=paste&mode=copy',
+                'icon' => 'copy.svg',
                 'button_callback' => ['tl_survey_page', 'copyPage'],
             ],
-            'cut'        => [
-                'label'           => &$GLOBALS['TL_LANG']['tl_survey_page']['cut'],
-                'href'            => 'act=paste&mode=cut',
-                'icon'            => 'cut.svg',
-                'attributes'      => 'onclick="Backend.getScrollOffset();"',
+            'cut' => [
+                'label' => &$GLOBALS['TL_LANG']['tl_survey_page']['cut'],
+                'href' => 'act=paste&mode=cut',
+                'icon' => 'cut.svg',
+                'attributes' => 'onclick="Backend.getScrollOffset();"',
                 'button_callback' => ['tl_survey_page', 'cutPage'],
             ],
-            'delete'     => [
-                'label'           => &$GLOBALS['TL_LANG']['tl_survey_page']['delete'],
-                'href'            => 'act=delete',
-                'icon'            => 'delete.svg',
-                'attributes'      => 'onclick="if (!confirm(\'' . ($GLOBALS['TL_LANG']['MSC']['deleteConfirm'] ?? null) . '\')) return false; Backend.getScrollOffset();"',
+            'delete' => [
+                'label' => &$GLOBALS['TL_LANG']['tl_survey_page']['delete'],
+                'href' => 'act=delete',
+                'icon' => 'delete.svg',
+                'attributes' => 'onclick="if (!confirm(\''.($GLOBALS['TL_LANG']['MSC']['deleteConfirm'] ?? null).'\')) return false; Backend.getScrollOffset();"',
                 'button_callback' => ['tl_survey_page', 'deletePage'],
             ],
-            'show'       => [
+            'show' => [
                 'label' => &$GLOBALS['TL_LANG']['tl_survey_page']['show'],
-                'href'  => 'act=show',
-                'icon'  => 'show.svg',
+                'href' => 'act=show',
+                'icon' => 'show.svg',
             ],
         ],
     ],
-    'palettes'    => [
+    'palettes' => [
         '__selector__' => ['type', 'useCustomNextButtonTitle'],
-        'default'      => '{type_legend},type;{title_legend},title,description;{intro_legend},introduction;{template_legend},page_template',
-        'result'       => '{type_legend},type;{title_legend},title,description;{intro_legend},introduction;{config_legend},useCustomNextButtonTitle;{template_legend},page_template',
+        'default' => '{type_legend},type;{title_legend},title,description;{intro_legend},introduction;{template_legend},page_template',
+        'result' => '{type_legend},type;{title_legend},title,description;{intro_legend},introduction;{config_legend},useCustomNextButtonTitle;{template_legend},page_template',
     ],
     'subpalettes' => [
         'useCustomNextButtonTitle' => 'customNextButtonTitle',
     ],
-    'fields'      => [
-        'id'                       => [
+    'fields' => [
+        'id' => [
             'sql' => 'int(10) unsigned NOT NULL auto_increment',
         ],
-        'tstamp'                   => [
+        'tstamp' => [
             'sql' => "int(10) unsigned NOT NULL default '0'",
         ],
-        'pid'                      => [
+        'pid' => [
             'sql' => "int(10) unsigned NOT NULL default '0'",
         ],
-        'sorting'                  => [
+        'sorting' => [
             'sql' => "int(10) unsigned NOT NULL default '0'",
         ],
-        'type'                     => [
-            'exclude'   => true,
-            'filter'    => true,
+        'type' => [
+            'exclude' => true,
+            'filter' => true,
             'inputType' => 'select',
-            'options'   => ['default', 'result'],
+            'options' => ['default', 'result'],
             'reference' => &$GLOBALS['TL_LANG']['tl_survey_page']['type'],
-            'eval'      => ['submitOnChange' => true, 'tl_class' => 'w50'],
-            'sql'       => ['name' => 'type', 'type' => 'string', 'length' => 8, 'default' => 'default'],
+            'eval' => ['submitOnChange' => true, 'tl_class' => 'w50'],
+            'sql' => ['name' => 'type', 'type' => 'string', 'length' => 8, 'default' => 'default'],
         ],
-        'title'                    => [
-            'label'     => &$GLOBALS['TL_LANG']['tl_survey_page']['title'],
-            'search'    => true,
-            'sorting'   => true,
-            'filter'    => true,
-            'flag'      => 1,
+        'title' => [
+            'label' => &$GLOBALS['TL_LANG']['tl_survey_page']['title'],
+            'search' => true,
+            'sorting' => true,
+            'filter' => true,
+            'flag' => 1,
             'inputType' => 'text',
-            'eval'      => ['mandatory' => true, 'maxlength' => 255, 'insertTag' => true],
-            'sql'       => "varchar(255) NOT NULL default ''",
+            'eval' => ['mandatory' => true, 'maxlength' => 255, 'insertTag' => true],
+            'sql' => "varchar(255) NOT NULL default ''",
         ],
-        'description'              => [
-            'label'     => &$GLOBALS['TL_LANG']['tl_survey_page']['description'],
-            'search'    => true,
+        'description' => [
+            'label' => &$GLOBALS['TL_LANG']['tl_survey_page']['description'],
+            'search' => true,
             'inputType' => 'textarea',
-            'eval'      => ['allowHtml' => true, 'style' => 'height:80px;'],
-            'sql'       => 'text NULL',
+            'eval' => ['allowHtml' => true, 'style' => 'height:80px;'],
+            'sql' => 'text NULL',
         ],
-        'language'                 => [
+        'language' => [
             'sql' => "varchar(32) NOT NULL default ''",
         ],
-        'introduction'             => [
-            'label'     => &$GLOBALS['TL_LANG']['tl_survey_page']['introduction'],
-            'default'   => '',
-            'search'    => true,
+        'introduction' => [
+            'label' => &$GLOBALS['TL_LANG']['tl_survey_page']['introduction'],
+            'default' => '',
+            'search' => true,
             'inputType' => 'textarea',
-            'eval'      => ['allowHtml' => true, 'style' => 'height:80px;', 'rte' => 'tinyMCE'],
-            'sql'       => 'text NOT NULL',
+            'eval' => ['allowHtml' => true, 'style' => 'height:80px;', 'rte' => 'tinyMCE'],
+            'sql' => 'text NOT NULL',
         ],
-        'conditions'               => [
-            'label'     => &$GLOBALS['TL_LANG']['tl_survey_page']['conditions'],
-            'default'   => '',
-            'search'    => true,
+        'conditions' => [
+            'label' => &$GLOBALS['TL_LANG']['tl_survey_page']['conditions'],
+            'default' => '',
+            'search' => true,
             'inputType' => 'conditionwizard',
-            'eval'      => [],
-            'sql'       => "varchar(1) NOT NULL default ''",
+            'eval' => [],
+            'sql' => "varchar(1) NOT NULL default ''",
         ],
-        'page_template'            => [
-            'label'     => &$GLOBALS['TL_LANG']['tl_survey_page']['page_template'],
-            'default'   => 'survey_questionblock',
+        'page_template' => [
+            'label' => &$GLOBALS['TL_LANG']['tl_survey_page']['page_template'],
+            'default' => 'survey_questionblock',
             'inputType' => 'select',
-            'eval'      => ['tl_class' => 'w50'],
-            'sql'       => "varchar(255) NOT NULL default 'survey_questionblock'",
+            'eval' => ['tl_class' => 'w50'],
+            'sql' => "varchar(255) NOT NULL default 'survey_questionblock'",
         ],
-        'pagetype'                 => [
+        'pagetype' => [
             'sql' => "varchar(30) NOT NULL default 'standard'",
         ],
         'useCustomNextButtonTitle' => [
-            'exclude'   => true,
+            'exclude' => true,
             'inputType' => 'checkbox',
-            'eval'      => ['tl_class' => 'w50', 'submitOnChange' => true],
-            'sql'       => "char(1) NOT NULL default ''",
+            'eval' => ['tl_class' => 'w50', 'submitOnChange' => true],
+            'sql' => "char(1) NOT NULL default ''",
         ],
-        'customNextButtonTitle'    => [
+        'customNextButtonTitle' => [
             'inputType' => 'text',
-            'eval'      => ['mandatory' => true, 'maxlength' => 128],
-            'sql'       => "varchar(128) NOT NULL default ''",
+            'eval' => ['mandatory' => true, 'maxlength' => 128],
+            'sql' => "varchar(128) NOT NULL default ''",
         ],
-        'hideBackButton'           => [
-            'exclude'   => true,
+        'hideBackButton' => [
+            'exclude' => true,
             'inputType' => 'checkbox',
-            'eval'      => ['tl_class' => 'w50'],
-            'sql'       => "char(1) NOT NULL default ''",
+            'eval' => ['tl_class' => 'w50'],
+            'sql' => "char(1) NOT NULL default ''",
         ],
     ],
 ];
@@ -210,10 +210,10 @@ class tl_survey_page extends Backend
     public function copyPage($row, $href, $label, $title, $icon, $attributes)
     {
         if ($this->hasData()) {
-            return $this->generateImage(preg_replace('/\.svg$/i', '_.svg', $icon)) . ' ';
+            return $this->generateImage(preg_replace('/\.svg$/i', '_.svg', $icon)).' ';
         }
 
-        return '<a href="' . $this->addToUrl($href . '&id=' . $row['id']) . '" title="' . StringUtil::specialchars($title) . '"' . $attributes . '>' . $this->generateImage($icon, $label) . '</a> ';
+        return '<a href="'.$this->addToUrl($href.'&id='.$row['id']).'" title="'.StringUtil::specialchars($title).'"'.$attributes.'>'.$this->generateImage($icon, $label).'</a> ';
     }
 
     /**
@@ -237,10 +237,10 @@ class tl_survey_page extends Backend
     public function cutPage($row, $href, $label, $title, $icon, $attributes)
     {
         if ($this->hasData()) {
-            return $this->generateImage(preg_replace('/\.svg$/i', '_.svg', $icon)) . ' ';
+            return $this->generateImage(preg_replace('/\.svg$/i', '_.svg', $icon)).' ';
         }
 
-        return '<a href="' . $this->addToUrl($href . '&id=' . $row['id']) . '" title="' . StringUtil::specialchars($title) . '"' . $attributes . '>' . $this->generateImage($icon, $label) . '</a> ';
+        return '<a href="'.$this->addToUrl($href.'&id='.$row['id']).'" title="'.StringUtil::specialchars($title).'"'.$attributes.'>'.$this->generateImage($icon, $label).'</a> ';
     }
 
     /**
@@ -264,16 +264,16 @@ class tl_survey_page extends Backend
     public function deletePage($row, $href, $label, $title, $icon, $attributes)
     {
         if ($this->hasData()) {
-            return $this->generateImage(preg_replace('/\.svg$/i', '_.svg', $icon)) . ' ';
+            return $this->generateImage(preg_replace('/\.svg$/i', '_.svg', $icon)).' ';
         }
 
-        return '<a href="' . $this->addToUrl($href . '&id=' . $row['id']) . '" title="' . StringUtil::specialchars($title) . '"' . $attributes . '>' . $this->generateImage($icon, $label) . '</a> ';
+        return '<a href="'.$this->addToUrl($href.'&id='.$row['id']).'" title="'.StringUtil::specialchars($title).'"'.$attributes.'>'.$this->generateImage($icon, $label).'</a> ';
     }
 
     protected function hasData()
     {
         if (null === $this->hasData) {
-            $resultModel   = SurveyResultModel::findBy(['pid=?'], [Input::get('id')]);
+            $resultModel = SurveyResultModel::findBy(['pid=?'], [Input::get('id')]);
             $this->hasData = null !== $resultModel && $resultModel->count() > 0;
         }
 

--- a/src/Resources/contao/elements/ContentSurvey.php
+++ b/src/Resources/contao/elements/ContentSurvey.php
@@ -85,7 +85,7 @@ class ContentSurvey extends ContentElement
             $GLOBALS['TL_JAVASCRIPT'] = ['bundles/hschottmsurvey/js/survey.js'];
         }
 
-        $surveyID = \strlen(Input::post('survey')) ? Input::post('survey') : $this->survey;
+        $surveyID = (Input::post('survey')) ? (int)Input::post('survey') : $this->survey;
 
         $this->objSurvey = $this->Database->prepare('SELECT * FROM tl_survey WHERE id=?')
             ->execute($surveyID)
@@ -205,7 +205,7 @@ class ContentSurvey extends ContentElement
 
         if (($page > 0 && $page <= \count($pages))) {
             if ('tl_survey' === Input::post('FORM_SUBMIT')) {
-                $goback = \strlen(Input::post('prev')) ? true : false;
+                $goback = Input::post('prev') ? true : false;
                 $surveypage = $this->createSurveyPage($pages[$page - 1], $page, true, $goback);
             }
         }
@@ -214,7 +214,7 @@ class ContentSurvey extends ContentElement
         $previouspage = $page;
 
         if (0 === \count($surveypage)) {
-            if (\strlen(Input::post('next'))) {
+            if (Input::post('next')) {
                 $pageid = $this->evaluateConditions($pages[$page - 1]);
 
                 if (null === $pageid) {
@@ -229,11 +229,11 @@ class ContentSurvey extends ContentElement
                 $this->insertNavigation($this->objSurvey->id, $this->pin, $this->User->id?? 0, $previouspage, $page);
             }
 
-            if (\strlen(Input::post('finish'))) {
+            if (Input::post('finish')) {
                 ++$page;
             }
 
-            if (\strlen(Input::post('prev'))) {
+            if (Input::post('prev')) {
                 $res = SurveyNavigationModel::findOneBy(['pid=?', 'pin=?', 'uid=?', 'topage=?'], [$this->objSurvey->id, $this->pin, 0 === \strlen($this->User->id) ? 0 : $this->User->id, $page], ['order' => 'tstamp DESC']);
 
                 if (null !== $res) {
@@ -243,7 +243,7 @@ class ContentSurvey extends ContentElement
                 }
             }
 
-            $surveypage = $this->createSurveyPage($pages[$page - 1], $page, false);
+            $surveypage = $this->createSurveyPage(($pages[(($page > 0) ? $page - 1 : 0)] ?? null), $page, false);
         }
 
         // save position of last page (for resume)
@@ -255,7 +255,7 @@ class ContentSurvey extends ContentElement
                 $res->save();
             }
 
-            if (\strlen($pages[$page - 1]['page_template'])) {
+            if ($pages[$page - 1]['page_template'] ?? false) {
                 $this->questionblock_template = $pages[$page - 1]['page_template'];
             }
         }
@@ -405,14 +405,14 @@ class ContentSurvey extends ContentElement
     {
         $this->questionpositions = [];
 
-        if (!\strlen($this->pin)) {
+        if (!$this->pin) {
             $this->pin = Input::post('pin');
         }
         $surveypage = [];
         $pagequestioncounter = 1;
         $doNotSubmit = false;
 
-        $questions = SurveyQuestionModel::findBy('pid', $pagerow['id'], ['order' => 'sorting']);
+        $questions = SurveyQuestionModel::findBy('pid', $pagerow['id'] ?? 0, ['order' => 'sorting']);
 
         if (null === $questions) {
             $questions = [];

--- a/src/Resources/contao/elements/ContentSurvey.php
+++ b/src/Resources/contao/elements/ContentSurvey.php
@@ -33,6 +33,7 @@ use Hschottm\SurveyBundle\DataContainer\SurveyPageContainer;
 
 /**
  * @property SurveyModel|Result $objSurvey
+ * @property Survey $svy
  */
 class ContentSurvey extends ContentElement
 {
@@ -130,7 +131,7 @@ class ContentSurvey extends ContentElement
 
             switch ($this->objSurvey->access) {
                 case 'anon':
-                    if ($this->objSurvey->usecookie && \strlen($_COOKIE['TLsvy_'.$this->objSurvey->id]) && false !== $this->svy->checkPINTAN($this->objSurvey->id, $_COOKIE['TLsvy_'.$this->objSurvey->id])) {
+                    if ($this->objSurvey->usecookie && !empty($_COOKIE['TLsvy_'.$this->objSurvey->id]) && false !== $this->svy->checkPINTAN($this->objSurvey->id, $_COOKIE['TLsvy_'.$this->objSurvey->id])) {
                         $page = $this->svy->getLastPageForPIN($this->objSurvey->id, $_COOKIE['TLsvy_'.$this->objSurvey->id]);
                         $this->pin = $_COOKIE['TLsvy_'.$this->objSurvey->id];
                     } else {
@@ -912,10 +913,10 @@ class ContentSurvey extends ContentElement
                 $status = '';
 
                 if ($this->objSurvey->usecookie) {
-                    $status = $this->svy->getSurveyStatus($this->objSurvey->id, $_COOKIE['TLsvy_'.$this->objSurvey->id]);
+                    $status = $this->svy->getSurveyStatus($this->objSurvey->id, $_COOKIE['TLsvy_'.$this->objSurvey->id] ?? null);
                 }
 
-                if (0 === strcmp($status, 'finished')) {
+                if (is_string($status) && (0 === strcmp($status, 'finished'))) {
                     $this->Template->errorMsg = $GLOBALS['TL_LANG']['ERR']['survey_already_finished'];
                     $this->Template->hideStartButtons = true;
                 }

--- a/src/Resources/contao/forms/FormMultipleChoiceQuestion.php
+++ b/src/Resources/contao/forms/FormMultipleChoiceQuestion.php
@@ -112,7 +112,7 @@ class FormMultipleChoiceQuestion extends FormQuestionWidget
         $submit_other = $this->getPost('other_question');
         $value = [];
         $value['value'] = $submit[$this->id];
-        $value['other'] = $submit_other[$this->id];
+        $value['other'] = $submit_other[$this->id] ?? null;
         $varInput = $this->validator($value);
         $this->value = $varInput;
     }

--- a/src/Resources/contao/models/SurveyResultModel.php
+++ b/src/Resources/contao/models/SurveyResultModel.php
@@ -30,6 +30,7 @@ use Contao\Model\Collection;
  * @property mixed  $result
  *
  * @method static array<static>|Collection|null findBy($val, array $opt = [])
+ * @method static array<static>|Collection|null findByPid($val, array $opt = [])
  */
 class SurveyResultModel extends Model
 {

--- a/src/Resources/contao/templates/survey/survey_answers_multiplechoice.html5
+++ b/src/Resources/contao/templates/survey/survey_answers_multiplechoice.html5
@@ -13,7 +13,7 @@
             <td class="counter"><?php echo $counter; ?>.</td>
             <td class="answer"><?php echo $choice['choice']; ?><?php if ($this->useCategories && ($choice['choice'] ?? false)):?>
                 <span style="color:#999;">[<?= $this->survey->getCategoryName($choice['category']) ?>]</span><?php endif; ?></td>
-            <td class="selections"><?php echo (($this->statistics['cumulated'][$id]) ? $this->statistics['cumulated'][$id] : 0); ?></td>
+            <td class="selections"><?php echo ($this->statistics['cumulated'][$id] ?? 0); ?></td>
         </tr>
     <?php $counter++; ?>
     <?php endforeach; ?>

--- a/src/Resources/contao/templates/survey/survey_question_multiplechoice.html5
+++ b/src/Resources/contao/templates/survey/survey_question_multiplechoice.html5
@@ -10,7 +10,7 @@
     <?php endforeach; ?>
 <?php endif; ?>
 <?php if ($this->blnOther && isset($this->values['other'])): ?>
-    <td><label for="ctrl_<?php echo $this->ctrl_id; ?>_<?php echo $counter; ?>"><?php echo $this->otherTitle; ?></label> <input type="text" name="other_<?php echo $this->ctrl_name; ?>" class="text<?php echo $this->ctrl_class; ?>" <?php if (strlen($this->values["other"])): ?>value="<?php echo Contao\StringUtil::specialchars($this->values['other']); ?>" <?php endif; ?>/></td>
+    <td><label for="ctrl_<?php echo $this->ctrl_id; ?>_<?php echo $counter; ?>"><?php echo $this->otherTitle; ?></label> <input type="text" name="other_<?php echo $this->ctrl_name; ?>" class="text<?php echo $this->ctrl_class; ?>" <?php if (isset($this->values["other"])): ?>value="<?php echo Contao\StringUtil::specialchars($this->values['other']); ?>" <?php endif; ?>/></td>
 <?php endif; ?>
 <?php $counter = 1; ?>
     </tr>
@@ -66,7 +66,7 @@
 <?php if ($this->singleResponse): ?>
 <?php $counter = 1; ?>
 <?php foreach ($this->choices as $choice): ?>
-<div><input type="radio" name="<?php echo $this->ctrl_name; ?>" id="ctrl_<?php echo $this->ctrl_id; ?>_<?php echo $counter; ?>" class="radio<?php echo $this->ctrl_class; ?>" value="<?php echo $counter; ?>"<?php if ($this->values['value'] == $counter): ?> checked="checked"<?php endif; ?> /> <label for="ctrl_<?php echo $this->ctrl_id; ?>_<?php echo $counter; ?>"><?php echo Contao\StringUtil::specialchars($choice); ?></label></div>
+<div><input type="radio" name="<?php echo $this->ctrl_name; ?>" id="ctrl_<?php echo $this->ctrl_id; ?>_<?php echo $counter; ?>" class="radio<?php echo $this->ctrl_class; ?>" value="<?php echo $counter; ?>"<?php if (($this->values['value'] ?? 0) == $counter): ?> checked="checked"<?php endif; ?> /> <label for="ctrl_<?php echo $this->ctrl_id; ?>_<?php echo $counter; ?>"><?php echo Contao\StringUtil::specialchars($choice); ?></label></div>
 <?php $counter++; ?>
 <?php endforeach; ?>
 <?php if ($this->blnOther && isset($this->values['value'])): ?>


### PR DESCRIPTION
This PR fixes a lot of php 8 array index warning and a bug in backend for multiple choice questions.

Changelog:
- Changed: refactored logic to disable tl_survey.access field to DataContainer class
- Changed: refactored logic to close tl_survey_page to DataContainer class
- Fixed: wrong comparison in CategoriesListener
- Fixed: buggy code in SurveyQuestionMultiplechoice leading to different return values
- Fixed: dublicated code in SurveyResultDetails
- Fixed: a lot of php 8 related array index issues (see #27)
- Fixed: tl_survey_page operations not correctly disabled