### PR TITLE
Follow up PHP fixes

### DIFF
--- a/src/Resources/contao/elements/ContentSurvey.php
+++ b/src/Resources/contao/elements/ContentSurvey.php
@@ -86,7 +86,7 @@ class ContentSurvey extends ContentElement
             $GLOBALS['TL_JAVASCRIPT'] = ['bundles/hschottmsurvey/js/survey.js'];
         }
 
-        $surveyID = \strlen(Input::post('survey')) ? Input::post('survey') : $this->survey;
+        $surveyID = !empty(Input::post('survey')) ? Input::post('survey') : $this->survey;
 
         $this->objSurvey = $this->Database->prepare('SELECT * FROM tl_survey WHERE id=?')
             ->execute($surveyID)


### PR DESCRIPTION
After https://github.com/pdir/contao-survey/commit/9eb849f137cd630c210dff1422941de2b0b609d9 one change from #29 was reverted, leading to the following error:

```
TypeError:
strlen(): Argument #1 ($str) must be of type string, null given

  at vendor\pdir\contao-survey\src\Resources\contao\elements\ContentSurvey.php:89
```

This PR fixes that.