### PR TITLE
Fix title logic

### DIFF
--- a/src/Resources/contao/forms/FormQuestionWidget.php
+++ b/src/Resources/contao/forms/FormQuestionWidget.php
@@ -134,7 +134,7 @@ class FormQuestionWidget extends Widget
                 break;
 
             case 'showTitle':
-                return false === $this->hidetitle;
+                return !$this->hidetitle;
                 break;
 
             case 'help':
@@ -161,7 +161,7 @@ class FormQuestionWidget extends Widget
 
     public function hasLabel()
     {
-        if ('' === $this->title || false === $this->showTitle) {
+        if ('' === $this->title || $this->showTitle) {
             return false;
         }
 


### PR DESCRIPTION
Currently the widgets do not show questions at all. The

```php
false === $this->hidetitle
```

check in `FormQuestionWidget::__get` for `showTitle` will _never_ be true because `tl_survey_question.hidetitle` is always a string and never a boolean.

Secondly, even when that is fixed, the `survey_questionblock` template would then output the title as the title - and then _again_ as the question. This is because the `FormQuestionWidget::hasLabel` check is wrong in the first place. No label should be generated iff:

* there is no title
* _or_ the title is already enabled to be shown (i.e. `hidetitle` is not `1`)

Otherwise you will end up with the title being displayed as _both_ the title _and_ the question, which is superfluous and I don't think this was the original intention.