### PR TITLE
Fix `immediate_start` check

### DIFF
--- a/src/Resources/contao/elements/ContentSurvey.php
+++ b/src/Resources/contao/elements/ContentSurvey.php
@@ -127,7 +127,7 @@ class ContentSurvey extends ContentElement
             $this->outIntroductionPage();
         }
         // check survey start
-        if (Input::post('start') || (1 === $this->objSurvey->immediate_start && !Input::post('FORM_SUBMIT'))) {
+        if (Input::post('start') || ($this->objSurvey->immediate_start && !Input::post('FORM_SUBMIT'))) {
             $page = 0;
 
             switch ($this->objSurvey->access) {


### PR DESCRIPTION
The `immediate_start` checkbox for a survey is currently not working. This is because `tl_survey.immediate_start` is a `char(1)` - but a strict type comparison against the integer `1` is used in the code. Imho it is fine to just use an implicit cast to `bool` here instead.